### PR TITLE
feat: add CI workflow and pre-commit hooks

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: DeterminateSystems/magic-nix-cache-action@v14
       - id: list
         run: |
-          cp user.nix.example user.nix
+          mkdir -p "$HOME/.nix-config" && cp user.nix.example "$HOME/.nix-config/user.nix"
           LINUX=$(nix eval .#homeConfigurations --apply builtins.attrNames --json --impure)
           echo "linux=$LINUX" >> "$GITHUB_OUTPUT"
           DARWIN=$(nix eval .#darwinConfigurations --apply builtins.attrNames --json --impure \
@@ -38,7 +38,7 @@ jobs:
           submodules: recursive
       - uses: DeterminateSystems/nix-installer-action@v22
       - uses: DeterminateSystems/magic-nix-cache-action@v14
-      - run: cp user.nix.example user.nix
+      - run: mkdir -p "$HOME/.nix-config" && cp user.nix.example "$HOME/.nix-config/user.nix"
       - run: nix flake check --impure
       - run: nix eval --file user.nix.example
 
@@ -62,7 +62,7 @@ jobs:
           extra-conf: |
             extra-platforms = aarch64-linux
       - uses: DeterminateSystems/magic-nix-cache-action@v14
-      - run: cp user.nix.example user.nix
+      - run: mkdir -p "$HOME/.nix-config" && cp user.nix.example "$HOME/.nix-config/user.nix"
       - run: nix build .#homeConfigurations.${{ matrix.profile }}.activationPackage --impure
 
   # ── Full system build for every Darwin profile ────────────────────────────────
@@ -79,7 +79,7 @@ jobs:
           submodules: recursive
       - uses: DeterminateSystems/nix-installer-action@v22
       - uses: DeterminateSystems/magic-nix-cache-action@v14
-      - run: cp user.nix.example user.nix
+      - run: mkdir -p "$HOME/.nix-config" && cp user.nix.example "$HOME/.nix-config/user.nix"
       - run: nix build .#darwinConfigurations.${{ matrix.config }}.system --impure
 
   # ── Lint: each tool is a separate job so failures are individually named ──────

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: nix-community/cache-nix-action@v7
         with:
           primary-key: nix-linux-eval-${{ hashFiles('flake.lock', '**/*.nix') }}
-          restore-keys: nix-linux-eval-
+          restore-prefixes-first-match: nix-linux-eval-
           gc-max-store-size-linux: 2147483648
       - id: list
         run: |
@@ -50,7 +50,7 @@ jobs:
       - uses: nix-community/cache-nix-action@v7
         with:
           primary-key: nix-linux-eval-${{ hashFiles('flake.lock', '**/*.nix') }}
-          restore-keys: nix-linux-eval-
+          restore-prefixes-first-match: nix-linux-eval-
           gc-max-store-size-linux: 2147483648
       - run: mkdir -p "$HOME/.nix-config" && cp user.nix.example "$HOME/.nix-config/user.nix"
       - run: nix flake check --impure
@@ -80,7 +80,7 @@ jobs:
       - uses: nix-community/cache-nix-action@v7
         with:
           primary-key: nix-linux-build-${{ hashFiles('flake.lock', '**/*.nix') }}
-          restore-keys: nix-linux-build-
+          restore-prefixes-first-match: nix-linux-build-
           gc-max-store-size-linux: 4294967296
       - run: mkdir -p "$HOME/.nix-config" && cp user.nix.example "$HOME/.nix-config/user.nix"
       - run: nix build .#homeConfigurations.${{ matrix.profile }}.activationPackage --impure
@@ -107,7 +107,7 @@ jobs:
       - uses: nix-community/cache-nix-action@v7
         with:
           primary-key: nix-macos-build-${{ hashFiles('flake.lock', '**/*.nix') }}
-          restore-keys: nix-macos-build-
+          restore-prefixes-first-match: nix-macos-build-
           gc-max-store-size-macos: 4294967296
       - run: mkdir -p "$HOME/.nix-config" && cp user.nix.example "$HOME/.nix-config/user.nix"
       - run: nix build .#darwinConfigurations.${{ matrix.config }}.system --impure
@@ -123,7 +123,7 @@ jobs:
       - uses: nix-community/cache-nix-action@v7
         with:
           primary-key: nix-linux-lint-${{ hashFiles('flake.lock') }}
-          restore-keys: nix-linux-lint-
+          restore-prefixes-first-match: nix-linux-lint-
           gc-max-store-size-linux: 1073741824
       - run: nix shell nixpkgs#alejandra -c alejandra --check .
 
@@ -135,7 +135,7 @@ jobs:
       - uses: nix-community/cache-nix-action@v7
         with:
           primary-key: nix-linux-lint-${{ hashFiles('flake.lock') }}
-          restore-keys: nix-linux-lint-
+          restore-prefixes-first-match: nix-linux-lint-
           gc-max-store-size-linux: 1073741824
       - run: nix shell nixpkgs#statix -c statix check
 
@@ -147,7 +147,7 @@ jobs:
       - uses: nix-community/cache-nix-action@v7
         with:
           primary-key: nix-linux-lint-${{ hashFiles('flake.lock') }}
-          restore-keys: nix-linux-lint-
+          restore-prefixes-first-match: nix-linux-lint-
           gc-max-store-size-linux: 1073741824
       - run: nix shell nixpkgs#deadnix -c deadnix --fail .
 
@@ -159,6 +159,6 @@ jobs:
       - uses: nix-community/cache-nix-action@v7
         with:
           primary-key: nix-linux-lint-${{ hashFiles('flake.lock') }}
-          restore-keys: nix-linux-lint-
+          restore-prefixes-first-match: nix-linux-lint-
           gc-max-store-size-linux: 1073741824
       - run: nix shell nixpkgs#markdownlint-cli -c markdownlint 'docs/**/*.md'

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -24,8 +24,12 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: recursive
-      - uses: DeterminateSystems/nix-installer-action@v22
-      - uses: DeterminateSystems/magic-nix-cache-action@v14
+      - uses: cachix/install-nix-action@v31
+      - uses: nix-community/cache-nix-action@v7
+        with:
+          primary-key: nix-linux-eval-${{ hashFiles('flake.lock', '**/*.nix') }}
+          restore-keys: nix-linux-eval-
+          gc-max-store-size-linux: 2147483648
       - id: list
         run: |
           mkdir -p "$HOME/.nix-config" && cp user.nix.example "$HOME/.nix-config/user.nix"
@@ -42,13 +46,19 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: recursive
-      - uses: DeterminateSystems/nix-installer-action@v22
-      - uses: DeterminateSystems/magic-nix-cache-action@v14
+      - uses: cachix/install-nix-action@v31
+      - uses: nix-community/cache-nix-action@v7
+        with:
+          primary-key: nix-linux-eval-${{ hashFiles('flake.lock', '**/*.nix') }}
+          restore-keys: nix-linux-eval-
+          gc-max-store-size-linux: 2147483648
       - run: mkdir -p "$HOME/.nix-config" && cp user.nix.example "$HOME/.nix-config/user.nix"
       - run: nix flake check --impure
       - run: nix eval --file user.nix.example
 
   # ── Full activation-package build for every Linux profile (including aarch64) ─
+  # All 16 profiles share one cache key — profiles overlap heavily in store
+  # content, so separate keys would fragment the 10 GB GHA cache quota.
   build-linux:
     needs: get-profiles
     runs-on: ubuntu-latest
@@ -63,11 +73,15 @@ jobs:
       - uses: docker/setup-qemu-action@v4
         with:
           platforms: arm64
-      - uses: DeterminateSystems/nix-installer-action@v22
+      - uses: cachix/install-nix-action@v31
         with:
-          extra-conf: |
+          extra_nix_config: |
             extra-platforms = aarch64-linux
-      - uses: DeterminateSystems/magic-nix-cache-action@v14
+      - uses: nix-community/cache-nix-action@v7
+        with:
+          primary-key: nix-linux-build-${{ hashFiles('flake.lock', '**/*.nix') }}
+          restore-keys: nix-linux-build-
+          gc-max-store-size-linux: 4294967296
       - run: mkdir -p "$HOME/.nix-config" && cp user.nix.example "$HOME/.nix-config/user.nix"
       - run: nix build .#homeConfigurations.${{ matrix.profile }}.activationPackage --impure
 
@@ -75,8 +89,6 @@ jobs:
   # All builds run on macos-14 (Apple Silicon). x86_64-darwin configs are built
   # via Rosetta 2 using extra-platforms = x86_64-darwin — same pattern as QEMU
   # for aarch64-linux. macos-13 (Intel) runners are deprecated and unavailable.
-  # magic-nix-cache is omitted: its proxy daemon conflicts with the Nix daemon
-  # on macOS runners; cache.nixos.org is used directly instead.
   build-darwin:
     needs: get-profiles
     runs-on: macos-14
@@ -88,42 +100,65 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: recursive
-      - uses: DeterminateSystems/nix-installer-action@v22
+      - uses: cachix/install-nix-action@v31
         with:
-          extra-conf: |
+          extra_nix_config: |
             extra-platforms = x86_64-darwin
+      - uses: nix-community/cache-nix-action@v7
+        with:
+          primary-key: nix-macos-build-${{ hashFiles('flake.lock', '**/*.nix') }}
+          restore-keys: nix-macos-build-
+          gc-max-store-size-macos: 4294967296
       - run: mkdir -p "$HOME/.nix-config" && cp user.nix.example "$HOME/.nix-config/user.nix"
       - run: nix build .#darwinConfigurations.${{ matrix.config }}.system --impure
 
   # ── Lint: each tool is a separate job so failures are individually named ──────
+  # All lint jobs share one cache key — they all pull from the same nixpkgs
+  # revision, so their store content overlaps almost entirely.
   lint-alejandra:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: DeterminateSystems/nix-installer-action@v22
-      - uses: DeterminateSystems/magic-nix-cache-action@v14
+      - uses: cachix/install-nix-action@v31
+      - uses: nix-community/cache-nix-action@v7
+        with:
+          primary-key: nix-linux-lint-${{ hashFiles('flake.lock') }}
+          restore-keys: nix-linux-lint-
+          gc-max-store-size-linux: 1073741824
       - run: nix shell nixpkgs#alejandra -c alejandra --check .
 
   lint-statix:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: DeterminateSystems/nix-installer-action@v22
-      - uses: DeterminateSystems/magic-nix-cache-action@v14
+      - uses: cachix/install-nix-action@v31
+      - uses: nix-community/cache-nix-action@v7
+        with:
+          primary-key: nix-linux-lint-${{ hashFiles('flake.lock') }}
+          restore-keys: nix-linux-lint-
+          gc-max-store-size-linux: 1073741824
       - run: nix shell nixpkgs#statix -c statix check
 
   lint-deadnix:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: DeterminateSystems/nix-installer-action@v22
-      - uses: DeterminateSystems/magic-nix-cache-action@v14
+      - uses: cachix/install-nix-action@v31
+      - uses: nix-community/cache-nix-action@v7
+        with:
+          primary-key: nix-linux-lint-${{ hashFiles('flake.lock') }}
+          restore-keys: nix-linux-lint-
+          gc-max-store-size-linux: 1073741824
       - run: nix shell nixpkgs#deadnix -c deadnix --fail .
 
   lint-markdownlint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: DeterminateSystems/nix-installer-action@v22
-      - uses: DeterminateSystems/magic-nix-cache-action@v14
+      - uses: cachix/install-nix-action@v31
+      - uses: nix-community/cache-nix-action@v7
+        with:
+          primary-key: nix-linux-lint-${{ hashFiles('flake.lock') }}
+          restore-keys: nix-linux-lint-
+          gc-max-store-size-linux: 1073741824
       - run: nix shell nixpkgs#markdownlint-cli -c markdownlint 'docs/**/*.md'

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,127 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  # ── Evaluate the flake and output profile name lists for downstream matrices ──
+  get-profiles:
+    runs-on: ubuntu-latest
+    outputs:
+      linux:  ${{ steps.list.outputs.linux }}
+      darwin: ${{ steps.list.outputs.darwin }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+      - uses: DeterminateSystems/nix-installer-action@v22
+      - uses: DeterminateSystems/magic-nix-cache-action@v14
+      - id: list
+        run: |
+          cp user.nix.example user.nix
+          LINUX=$(nix eval .#homeConfigurations --apply builtins.attrNames --json --impure)
+          echo "linux=$LINUX" >> "$GITHUB_OUTPUT"
+          DARWIN=$(nix eval .#darwinConfigurations --apply builtins.attrNames --json --impure \
+            | jq -c '[.[] | {config: ., runner: (if endswith("-aarch64") then "macos-14" else "macos-13" end)}]')
+          echo "darwin=$DARWIN" >> "$GITHUB_OUTPUT"
+
+  # ── nix flake check + validate the example identity file ─────────────────────
+  flake-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+      - uses: DeterminateSystems/nix-installer-action@v22
+      - uses: DeterminateSystems/magic-nix-cache-action@v14
+      - run: cp user.nix.example user.nix
+      - run: nix flake check --impure
+      - run: nix eval --file user.nix.example
+
+  # ── Full activation-package build for every Linux profile (including aarch64) ─
+  build-linux:
+    needs: get-profiles
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        profile: ${{ fromJSON(needs.get-profiles.outputs.linux) }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+      - uses: docker/setup-qemu-action@v4
+        with:
+          platforms: arm64
+      - uses: DeterminateSystems/nix-installer-action@v22
+        with:
+          extra-conf: |
+            extra-platforms = aarch64-linux
+      - uses: DeterminateSystems/magic-nix-cache-action@v14
+      - run: cp user.nix.example user.nix
+      - run: nix build .#homeConfigurations.${{ matrix.profile }}.activationPackage --impure
+
+  # ── Full system build for every Darwin profile ────────────────────────────────
+  build-darwin:
+    needs: get-profiles
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.get-profiles.outputs.darwin) }}
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+      - uses: DeterminateSystems/nix-installer-action@v22
+      - uses: DeterminateSystems/magic-nix-cache-action@v14
+      - run: cp user.nix.example user.nix
+      - run: nix build .#darwinConfigurations.${{ matrix.config }}.system --impure
+
+  # ── Lint: each tool is a separate job so failures are individually named ──────
+  lint-alejandra:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: DeterminateSystems/nix-installer-action@v22
+      - uses: DeterminateSystems/magic-nix-cache-action@v14
+      - run: nix shell nixpkgs#alejandra -c alejandra --check .
+
+  lint-statix:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: DeterminateSystems/nix-installer-action@v22
+      - uses: DeterminateSystems/magic-nix-cache-action@v14
+      - run: nix shell nixpkgs#statix -c statix check
+
+  lint-deadnix:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: DeterminateSystems/nix-installer-action@v22
+      - uses: DeterminateSystems/magic-nix-cache-action@v14
+      - run: nix shell nixpkgs#deadnix -c deadnix --fail .
+
+  lint-markdownlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: DeterminateSystems/nix-installer-action@v22
+      - uses: DeterminateSystems/magic-nix-cache-action@v14
+      - run: nix shell nixpkgs#markdownlint-cli -c markdownlint 'docs/**/*.md'
+
+  # ── Secret scanning on every push ─────────────────────────────────────────────
+  secrets:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: gitleaks/gitleaks-action@v3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -72,11 +72,8 @@ jobs:
   # ── Full system build for every Darwin profile ────────────────────────────────
   # Uses GitHub-hosted macOS runners (free for public repos, no minute cap).
   # macos-14 = Apple Silicon (aarch64), macos-13 = Intel (x86_64).
-  # Restricted to same-repo events: fork PRs cannot run code on macOS runners
-  # (GitHub security recommendation for any runner used with untrusted code).
   build-darwin:
     needs: get-profiles
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -32,7 +32,7 @@ jobs:
           LINUX=$(nix eval .#homeConfigurations --apply builtins.attrNames --json --impure)
           echo "linux=$LINUX" >> "$GITHUB_OUTPUT"
           DARWIN=$(nix eval .#darwinConfigurations --apply builtins.attrNames --json --impure \
-            | jq -c '[.[] | {config: ., runner: (if endswith("-aarch64") then "macos-14" else "macos-13" end)}]')
+            | jq -c '[.[] | {config: .}]')
           echo "darwin=$DARWIN" >> "$GITHUB_OUTPUT"
 
   # ── nix flake check + validate the example identity file ─────────────────────
@@ -72,20 +72,24 @@ jobs:
       - run: nix build .#homeConfigurations.${{ matrix.profile }}.activationPackage --impure
 
   # ── Full system build for every Darwin profile ────────────────────────────────
-  # Uses GitHub-hosted macOS runners (free for public repos, no minute cap).
-  # macos-14 = Apple Silicon (aarch64), macos-13 = Intel (x86_64).
+  # All builds run on macos-14 (Apple Silicon). x86_64-darwin configs are built
+  # via Rosetta 2 using extra-platforms = x86_64-darwin — same pattern as QEMU
+  # for aarch64-linux. macos-13 (Intel) runners are deprecated and unavailable.
   build-darwin:
     needs: get-profiles
+    runs-on: macos-14
     strategy:
       fail-fast: false
       matrix:
         include: ${{ fromJSON(needs.get-profiles.outputs.darwin) }}
-    runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v6
         with:
           submodules: recursive
       - uses: DeterminateSystems/nix-installer-action@v22
+        with:
+          extra-conf: |
+            extra-platforms = x86_64-darwin
       - uses: DeterminateSystems/magic-nix-cache-action@v14
       - run: mkdir -p "$HOME/.nix-config" && cp user.nix.example "$HOME/.nix-config/user.nix"
       - run: nix build .#darwinConfigurations.${{ matrix.config }}.system --impure

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -75,6 +75,8 @@ jobs:
   # All builds run on macos-14 (Apple Silicon). x86_64-darwin configs are built
   # via Rosetta 2 using extra-platforms = x86_64-darwin — same pattern as QEMU
   # for aarch64-linux. macos-13 (Intel) runners are deprecated and unavailable.
+  # magic-nix-cache is omitted: its proxy daemon conflicts with the Nix daemon
+  # on macOS runners; cache.nixos.org is used directly instead.
   build-darwin:
     needs: get-profiles
     runs-on: macos-14
@@ -90,7 +92,6 @@ jobs:
         with:
           extra-conf: |
             extra-platforms = x86_64-darwin
-      - uses: DeterminateSystems/magic-nix-cache-action@v14
       - run: mkdir -p "$HOME/.nix-config" && cp user.nix.example "$HOME/.nix-config/user.nix"
       - run: nix build .#darwinConfigurations.${{ matrix.config }}.system --impure
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -4,6 +4,10 @@ on:
   push:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
@@ -66,8 +70,13 @@ jobs:
       - run: nix build .#homeConfigurations.${{ matrix.profile }}.activationPackage --impure
 
   # ── Full system build for every Darwin profile ────────────────────────────────
+  # Uses GitHub-hosted macOS runners (free for public repos, no minute cap).
+  # macos-14 = Apple Silicon (aarch64), macos-13 = Intel (x86_64).
+  # Restricted to same-repo events: fork PRs cannot run code on macOS runners
+  # (GitHub security recommendation for any runner used with untrusted code).
   build-darwin:
     needs: get-profiles
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -2,7 +2,9 @@ name: CI
 
 on:
   push:
+    branches: [main]
   pull_request:
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -120,14 +122,3 @@ jobs:
       - uses: DeterminateSystems/nix-installer-action@v22
       - uses: DeterminateSystems/magic-nix-cache-action@v14
       - run: nix shell nixpkgs#markdownlint-cli -c markdownlint 'docs/**/*.md'
-
-  # ── Secret scanning on every push ─────────────────────────────────────────────
-  secrets:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-      - uses: gitleaks/gitleaks-action@v3
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,20 @@
+name: Security
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  secrets:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: gitleaks/gitleaks-action@v3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,5 @@
+MD013: false
+MD022: false
+MD024:
+  siblings_only: true
+MD031: false

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -3,3 +3,4 @@ MD022: false
 MD024:
   siblings_only: true
 MD031: false
+MD060: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,24 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-merge-conflict
+      - id: check-added-large-files
+
+  - repo: https://github.com/kamadorueda/alejandra
+    rev: 4.0.0
+    hooks:
+      - id: alejandra-nix
+
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.30.1
+    hooks:
+      - id: gitleaks
+
+  - repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: v0.48.0
+    hooks:
+      - id: markdownlint
+        files: ^docs/

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -122,6 +122,20 @@ cat ~/.ssh/<sshKey>.pub
 
 `<sshKey>` is the prefix of your personal email (derived automatically from `user.nix`).
 
+### 9. Activate pre-commit hooks (dev profile only)
+
+`pre-commit` is installed by the `dev` profile — no separate install needed. After first `home-manager switch`, wire up the hooks for this repo clone:
+
+```sh
+pre-commit install
+```
+
+This runs automatically on every `git commit` from that point on. To run all checks manually:
+
+```sh
+pre-commit run --all-files
+```
+
 ---
 
 ## macOS (nix-darwin)
@@ -156,7 +170,7 @@ $EDITOR ~/.config/secrets/env
 ### 5. Apply
 
 ```sh
-sudo darwin-rebuild switch --flake ~/.nix-config#personal-darwin
+sudo darwin-rebuild switch --flake ~/.nix-config#personal-darwin --impure
 ```
 
 ---

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -16,7 +16,7 @@
 
 Profiles are composed from three axes by `mkProfile` in `flake.nix`. You never manually list modules.
 
-```
+```text
 context : personal | work
 tier    : minimal | dev | server
 withGui : false | true  (auto-selects gui-linux or gui-darwin)

--- a/flake.nix
+++ b/flake.nix
@@ -228,10 +228,7 @@
     };
 
     # ── nixosConfigurations ─────────────────────────────────────────────────
-    # Uncomment and add hardware-configuration.nix when setting up a real NixOS machine.
-    # nixosConfigurations = {
-    #   "personal-nixos" = mkNixosConfig { context = "personal"; system = "x86_64-linux"; };
-    #   "work-nixos"     = mkNixosConfig { context = "work";     system = "x86_64-linux"; };
-    # };
+    # NixOS support is tracked in issue #5. Requires hardware-configuration.nix
+    # and a mkNixosConfig helper (analogous to mkDarwinConfig above).
   };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -15,165 +15,223 @@
     };
   };
 
-  outputs = inputs@{ self, nixpkgs, nix-darwin, home-manager, rust-overlay, ... }:
-    let
-      # ── Identity ────────────────────────────────────────────────────────────
-      # Identity is loaded from user.nix (gitignored, never committed).
-      # Copy user.nix.example to user.nix and fill in your values.
-      # builtins.getEnv is impure (value varies per eval), so all home-manager
-      # switch calls require --impure. Alternatives (absolute path, sops-nix)
-      # trade portability or simplicity — see docs for tradeoff discussion.
-      homeDir     = builtins.getEnv "HOME";
-      userNixPath = homeDir + "/.nix-config/user.nix";
-      userBase    = if homeDir != "" && builtins.pathExists userNixPath
-                    then import userNixPath
-                    else import (self + /user.nix.example);
-      user = userBase // {
+  outputs = {
+    self,
+    nixpkgs,
+    nix-darwin,
+    home-manager,
+    rust-overlay,
+    ...
+  }: let
+    # ── Identity ────────────────────────────────────────────────────────────
+    # Identity is loaded from user.nix (gitignored, never committed).
+    # Copy user.nix.example to user.nix and fill in your values.
+    # builtins.getEnv is impure (value varies per eval), so all home-manager
+    # switch calls require --impure. Alternatives (absolute path, sops-nix)
+    # trade portability or simplicity — see docs for tradeoff discussion.
+    homeDir = builtins.getEnv "HOME";
+    userNixPath = homeDir + "/.nix-config/user.nix";
+    userBase =
+      if homeDir != "" && builtins.pathExists userNixPath
+      then import userNixPath
+      else import (self + /user.nix.example);
+    user =
+      userBase
+      // {
         # Derive SSH key name from email prefix — key file: ~/.ssh/<sshKey>
         sshKey = builtins.elemAt (builtins.split "@" userBase.email) 0;
       };
 
-      pkgsConfig = { allowUnfree = true; };
+    pkgsConfig = {allowUnfree = true;};
 
-      # ── Helpers ──────────────────────────────────────────────────────────────
-      isLinux  = s: builtins.elem s [ "x86_64-linux"  "aarch64-linux"  ];
-      isDarwin = s: builtins.elem s [ "x86_64-darwin" "aarch64-darwin" ];
+    # ── Helpers ──────────────────────────────────────────────────────────────
+    isLinux = s: builtins.elem s ["x86_64-linux" "aarch64-linux"];
 
-      # nixpkgs with rust-overlay applied
-      mkPkgs = system: import nixpkgs {
+    # nixpkgs with rust-overlay applied
+    mkPkgs = system:
+      import nixpkgs {
         inherit system;
-        config   = pkgsConfig;
-        overlays = [ rust-overlay.overlays.default ];
+        config = pkgsConfig;
+        overlays = [rust-overlay.overlays.default];
       };
 
-      # context and user are threaded into all modules via specialArgs so modules
-      # can gate features (work.nix inclusion, copilot symlink, CLAUDE_PROFILE) on them.
-      mkSpecialArgs = system: context: { inherit system self user context; };
+    # context and user are threaded into all modules via specialArgs so modules
+    # can gate features (work.nix inclusion, copilot symlink, CLAUDE_PROFILE) on them.
+    mkSpecialArgs = system: context: {inherit system self user context;};
 
-      # ── Profile compositor ───────────────────────────────────────────────────
-      # Produces the ordered module list for a profile.
-      # context : "personal" | "work"
-      # tier    : "minimal" | "dev" | "server"
-      # withGui : bool — gui module auto-selected from system
-      mkProfile = { context, tier, withGui, system }:
-        let
-          tierMods = {
-            minimal = [];
-            dev     = [ ./modules/dev.nix ];
-            server  = [ ./modules/server.nix ];
-          }.${tier};
-
-          contextMods =
-            if context == "work" then [ ./modules/work.nix ] else [];
-
-          guiMods =
-            if !withGui     then []
-            else if isLinux  system then [ ./modules/gui-linux.nix  ]
-            else                         [ ./modules/gui-darwin.nix ];
-        in
-          [ ./modules/base.nix ] ++ tierMods ++ contextMods ++ guiMods;
-
-      # ── Home Manager (standalone Linux/WSL2) ────────────────────────────────
-      mkHomeConfig = { context, tier, withGui, system, ... }:
-        home-manager.lib.homeManagerConfiguration {
-          pkgs = mkPkgs system;
-          extraSpecialArgs = mkSpecialArgs system context;
-          modules =
-            (mkProfile { inherit context tier withGui system; })
-            ++ [ { nixpkgs.config = pkgsConfig; } ];
-        };
-
-      # Both x86_64 and aarch64 variants for a Linux profile
-      mkLinuxPair = args:
+    # ── Profile compositor ────────────────────────────────────────────────────
+    # Produces the ordered module list for a profile.
+    # context : "personal" | "work"
+    # tier    : "minimal" | "dev" | "server"
+    # withGui : bool — gui module auto-selected from system
+    mkProfile = {
+      context,
+      tier,
+      withGui,
+      system,
+    }: let
+      tierMods =
         {
-          "${args.name}"         = mkHomeConfig (args // { system = "x86_64-linux";  });
-          "${args.name}-aarch64" = mkHomeConfig (args // { system = "aarch64-linux"; });
+          minimal = [];
+          dev = [./modules/dev.nix];
+          server = [./modules/server.nix];
+        }.${
+          tier
         };
 
-      # ── Darwin (nix-darwin + home-manager) ──────────────────────────────────
-      # Darwin always includes GUI — nix-darwin implies a graphical macOS environment.
-      # Linux profiles use withGui to opt in; macOS never runs headless via nix-darwin.
-      mkDarwinConfig = { context, system }:
-        nix-darwin.lib.darwinSystem {
-          inherit system;
-          specialArgs = mkSpecialArgs system context;
-          modules = [
-            ./system/darwin.nix
-            home-manager.darwinModules.home-manager
-            {
-              nixpkgs.config   = pkgsConfig;
-              nixpkgs.overlays = [ rust-overlay.overlays.default ];
-              home-manager.useGlobalPkgs        = true;
-              home-manager.useUserPackages      = false;
-              home-manager.backupFileExtension  = "bk";
-              home-manager.extraSpecialArgs     = mkSpecialArgs system context;
-              home-manager.users.${user.username} = {
-                imports = mkProfile {
-                  inherit context system;
-                  tier    = "dev";
-                  withGui = true;
-                };
-              };
-            }
-          ];
-        };
+      contextMods =
+        if context == "work"
+        then [./modules/work.nix]
+        else [];
 
-      # ── NixOS ────────────────────────────────────────────────────────────────
-      mkNixosConfig = { context, system }:
-        nixpkgs.lib.nixosSystem {
-          inherit system;
-          specialArgs = mkSpecialArgs system context;
-          modules = [
-            ./system/nixos.nix
-            home-manager.nixosModules.home-manager
-            {
-              nixpkgs.config = pkgsConfig;
-              home-manager.useGlobalPkgs        = true;
-              home-manager.useUserPackages      = true;
-              home-manager.backupFileExtension  = "bk";
-              home-manager.extraSpecialArgs     = mkSpecialArgs system context;
-              home-manager.users.${user.username} = {
-                imports = mkProfile {
-                  inherit context system;
-                  tier    = "dev";
-                  withGui = true;
-                };
-              };
-            }
-          ];
-        };
+      guiMods =
+        if !withGui
+        then []
+        else if isLinux system
+        then [./modules/gui-linux.nix]
+        else [./modules/gui-darwin.nix];
+    in
+      [./modules/base.nix] ++ tierMods ++ contextMods ++ guiMods;
 
-    in {
-      # ── homeConfigurations ──────────────────────────────────────────────────
-      # Bootstrap: nix run home-manager -- switch --flake ~/.nix-config#<name>
-      # After first apply: home-manager switch --flake ~/.nix-config#<name>
-      #
-      # To add a profile: add a mkLinuxPair call below and pick context/tier/withGui.
-      # See modules/ for what each tier/context/gui module provides.
-      homeConfigurations =
-        (mkLinuxPair { name = "personal";         context = "personal"; tier = "dev";     withGui = false; }) //
-        (mkLinuxPair { name = "personal-gui";     context = "personal"; tier = "dev";     withGui = true;  }) //
-        (mkLinuxPair { name = "personal-minimal"; context = "personal"; tier = "minimal"; withGui = false; }) //
-        (mkLinuxPair { name = "personal-server";  context = "personal"; tier = "server";  withGui = false; }) //
-        (mkLinuxPair { name = "work";             context = "work";     tier = "dev";     withGui = false; }) //
-        (mkLinuxPair { name = "work-gui";         context = "work";     tier = "dev";     withGui = true;  }) //
-        (mkLinuxPair { name = "work-minimal";     context = "work";     tier = "minimal"; withGui = false; }) //
-        (mkLinuxPair { name = "work-server";      context = "work";     tier = "server";  withGui = false; });
-
-      # ── darwinConfigurations ────────────────────────────────────────────────
-      # Bootstrap: sudo darwin-rebuild switch --flake ~/.nix-config#<name>
-      darwinConfigurations = {
-        "personal-darwin"         = mkDarwinConfig { context = "personal"; system = "x86_64-darwin";  };
-        "personal-darwin-aarch64" = mkDarwinConfig { context = "personal"; system = "aarch64-darwin"; };
-        "work-darwin"             = mkDarwinConfig { context = "work";     system = "x86_64-darwin";  };
-        "work-darwin-aarch64"     = mkDarwinConfig { context = "work";     system = "aarch64-darwin"; };
+    # ── Home Manager (standalone Linux/WSL2) ────────────────────────────────
+    mkHomeConfig = {
+      context,
+      tier,
+      withGui,
+      system,
+      ...
+    }:
+      home-manager.lib.homeManagerConfiguration {
+        pkgs = mkPkgs system;
+        extraSpecialArgs = mkSpecialArgs system context;
+        modules =
+          (mkProfile {inherit context tier withGui system;})
+          ++ [{nixpkgs.config = pkgsConfig;}];
       };
 
-      # ── nixosConfigurations ─────────────────────────────────────────────────
-      # Uncomment and add hardware-configuration.nix when setting up a real NixOS machine.
-      # nixosConfigurations = {
-      #   "personal-nixos" = mkNixosConfig { context = "personal"; system = "x86_64-linux"; };
-      #   "work-nixos"     = mkNixosConfig { context = "work";     system = "x86_64-linux"; };
-      # };
+    # Both x86_64 and aarch64 variants for a Linux profile
+    mkLinuxPair = args: {
+      "${args.name}" = mkHomeConfig (args // {system = "x86_64-linux";});
+      "${args.name}-aarch64" = mkHomeConfig (args // {system = "aarch64-linux";});
     };
+
+    # ── Darwin (nix-darwin + home-manager) ──────────────────────────────────
+    # Darwin always includes GUI — nix-darwin implies a graphical macOS environment.
+    # Linux profiles use withGui to opt in; macOS never runs headless via nix-darwin.
+    mkDarwinConfig = {
+      context,
+      system,
+    }:
+      nix-darwin.lib.darwinSystem {
+        inherit system;
+        specialArgs = mkSpecialArgs system context;
+        modules = [
+          ./system/darwin.nix
+          home-manager.darwinModules.home-manager
+          {
+            nixpkgs = {
+              config = pkgsConfig;
+              overlays = [rust-overlay.overlays.default];
+            };
+            home-manager = {
+              useGlobalPkgs = true;
+              useUserPackages = false;
+              backupFileExtension = "bk";
+              extraSpecialArgs = mkSpecialArgs system context;
+              users.${user.username} = {
+                imports = mkProfile {
+                  inherit context system;
+                  tier = "dev";
+                  withGui = true;
+                };
+              };
+            };
+          }
+        ];
+      };
+  in {
+    # ── homeConfigurations ──────────────────────────────────────────────────
+    # Bootstrap: nix run home-manager -- switch --flake ~/.nix-config#<name>
+    # After first apply: home-manager switch --flake ~/.nix-config#<name>
+    #
+    # To add a profile: add a mkLinuxPair call below and pick context/tier/withGui.
+    # See modules/ for what each tier/context/gui module provides.
+    homeConfigurations =
+      (mkLinuxPair {
+        name = "personal";
+        context = "personal";
+        tier = "dev";
+        withGui = false;
+      })
+      // (mkLinuxPair {
+        name = "personal-gui";
+        context = "personal";
+        tier = "dev";
+        withGui = true;
+      })
+      // (mkLinuxPair {
+        name = "personal-minimal";
+        context = "personal";
+        tier = "minimal";
+        withGui = false;
+      })
+      // (mkLinuxPair {
+        name = "personal-server";
+        context = "personal";
+        tier = "server";
+        withGui = false;
+      })
+      // (mkLinuxPair {
+        name = "work";
+        context = "work";
+        tier = "dev";
+        withGui = false;
+      })
+      // (mkLinuxPair {
+        name = "work-gui";
+        context = "work";
+        tier = "dev";
+        withGui = true;
+      })
+      // (mkLinuxPair {
+        name = "work-minimal";
+        context = "work";
+        tier = "minimal";
+        withGui = false;
+      })
+      // (mkLinuxPair {
+        name = "work-server";
+        context = "work";
+        tier = "server";
+        withGui = false;
+      });
+
+    # ── darwinConfigurations ────────────────────────────────────────────────
+    # Bootstrap: sudo darwin-rebuild switch --flake ~/.nix-config#<name>
+    darwinConfigurations = {
+      "personal-darwin" = mkDarwinConfig {
+        context = "personal";
+        system = "x86_64-darwin";
+      };
+      "personal-darwin-aarch64" = mkDarwinConfig {
+        context = "personal";
+        system = "aarch64-darwin";
+      };
+      "work-darwin" = mkDarwinConfig {
+        context = "work";
+        system = "x86_64-darwin";
+      };
+      "work-darwin-aarch64" = mkDarwinConfig {
+        context = "work";
+        system = "aarch64-darwin";
+      };
+    };
+
+    # ── nixosConfigurations ─────────────────────────────────────────────────
+    # Uncomment and add hardware-configuration.nix when setting up a real NixOS machine.
+    # nixosConfigurations = {
+    #   "personal-nixos" = mkNixosConfig { context = "personal"; system = "x86_64-linux"; };
+    #   "work-nixos"     = mkNixosConfig { context = "work";     system = "x86_64-linux"; };
+    # };
+  };
 }

--- a/modules/base.nix
+++ b/modules/base.nix
@@ -1,7 +1,12 @@
-{ config, pkgs, lib, system, user, context, self, ... }:
-
-let
-  home = config.home.homeDirectory;
+{
+  config,
+  pkgs,
+  lib,
+  user,
+  context,
+  ...
+}: let
+  homeDir = config.home.homeDirectory;
 
   commonAliases = {};
 
@@ -24,387 +29,415 @@ let
       source "$HOME/.config/secrets/env"
     fi
   '';
-in
-{
-  home.username      = user.username;
-  # mkForce overrides HM's default homeDirectory derivation, which is unreliable
-  # on WSL2 and non-standard Linux setups where /home may not match expectations.
-  home.homeDirectory = lib.mkForce (
-    if pkgs.stdenv.isDarwin then "/Users/${user.username}"
-    else "/home/${user.username}"
-  );
+in {
+  home = {
+    inherit (user) username;
+    # mkForce overrides HM's default homeDirectory derivation, which is unreliable
+    # on WSL2 and non-standard Linux setups where /home may not match expectations.
+    homeDirectory = lib.mkForce (
+      if pkgs.stdenv.isDarwin
+      then "/Users/${user.username}"
+      else "/home/${user.username}"
+    );
 
-  home.sessionVariables.EDITOR         = "vim";
-  home.sessionVariables.CLAUDE_PROFILE = context;
-
-  # Binaries installed via `cargo install` outside Nix land here
-  home.sessionPath = [ "$HOME/.cargo/bin" "$HOME/.npm-global/bin" ];
-
-  home.packages = with pkgs; [
-    # Fonts — used everywhere for terminal rendering and prompt icons
-    fira-code
-    nerd-fonts.fira-code
-
-    # Home Manager — needed for setup across all profiles and devices
-    pkgs.home-manager
-
-    # just — task runner / discoverability layer (`just --list` shows all commands)
-    just
-
-    # CLI essentials
-    jq
-    ripgrep
-    fd
-    bat
-    eza
-    delta
-    lazygit
-    git-lfs
-    wget
-    btop
-    neofetch
-  ];
-
-  # ── Shells ───────────────────────────────────────────────────────────────────
-
-  programs.zsh = {
-    enable           = true;
-    enableCompletion = true;
-    shellAliases     = commonAliases;
-    # envExtra → .zshenv (sourced first, before .zshrc). Nix must be on PATH
-    # before tool integrations (atuin, fnm, zoxide) evaluate their init hooks.
-    envExtra    = nixProfileInit;
-    initContent = envLocalInit + ''
-      # Word navigation: Alt/Option+arrow. Alacritty with option_as_alt sends
-      # xterm-style sequences on macOS; Linux terminals send the same sequences.
-      bindkey '^[[1;3D' backward-word
-      bindkey '^[[1;3C' forward-word
-      # Home/End keys (also covers Cmd+Left/Right via Alacritty keybindings.toml)
-      bindkey '^[[H' beginning-of-line
-      bindkey '^[[F' end-of-line
-    '';
-  };
-
-  programs.bash = {
-    enable           = true;
-    enableCompletion = true;
-    shellAliases     = commonAliases;
-    profileExtra = nixProfileInit;
-    initExtra    = envLocalInit;
-  };
-
-  # ── Prompt ───────────────────────────────────────────────────────────────────
-
-  programs.starship = {
-    enable                = true;
-    enableZshIntegration  = true;
-    enableBashIntegration = true;
-    settings = {
-      format = "$os$username$hostname$directory$git_branch$git_status$aws$rust$python$golang$nodejs$package$cmd_duration\n$character";
-
-      aws = {
-        format        = "[$symbol$region]($style) ";
-        force_display = false;
-        region_aliases = {
-          "us-east-1"      = "va";
-          "us-east-2"      = "oh";
-          "us-west-1"      = "ca";
-          "us-west-2"      = "or";
-          "af-south-1"     = "cape";
-          "ap-east-1"      = "hk";
-          "ap-south-1"     = "mum";
-          "ap-south-2"     = "hyd";
-          "ap-southeast-1" = "sg";
-          "ap-southeast-2" = "syd";
-          "ap-southeast-3" = "jkt";
-          "ap-southeast-4" = "mel";
-          "ap-southeast-5" = "my";
-          "ap-southeast-6" = "nz";
-          "ap-southeast-7" = "th";
-          "ap-northeast-1" = "tok";
-          "ap-northeast-2" = "kr";
-          "ap-northeast-3" = "osk";
-          "ap-east-2"      = "tw";
-          "ca-central-1"   = "ca";
-          "ca-west-1"      = "cal";
-          "cn-north-1"     = "bj";
-          "cn-northwest-1" = "nx";
-          "eu-central-1"   = "de";
-          "eu-central-2"   = "ch";
-          "eu-north-1"     = "se";
-          "eu-south-1"     = "it";
-          "eu-south-2"     = "es";
-          "eu-west-1"      = "ie";
-          "eu-west-2"      = "ldn";
-          "eu-west-3"      = "fr";
-          "me-central-1"   = "ae";
-          "me-south-1"     = "bh";
-          "mx-central-1"   = "mx";
-          "sa-east-1"      = "br";
-          "us-gov-east-1"  = "gov-e";
-          "us-gov-west-1"  = "gov-w";
-        };
-      };
-
-      character = {
-        success_symbol = "[❯](bold green)";
-        error_symbol   = "[❯](bold red)";
-      };
-
-      cmd_duration = {
-        min_time = 2000;
-        format   = "took [$duration]($style) ";
-        style    = "bold yellow";
-      };
-
-      directory.truncation_length = 3;
-
-      git_branch.symbol = "🌱 ";
-
-      git_status = {
-        ahead    = "⇡\${count}";
-        diverged = "⇕⇡\${ahead_count}⇣\${behind_count}";
-        behind   = "⇣\${count}";
-      };
-
-      hostname = {
-        ssh_only = false;
-        format   = "[@](black)([$ssh_symbol]($style))[$hostname](bold blue) ";
-      };
-
-      os.disabled = false;
-
-      package.format = "[$symbol$version]($style) ";
-
-      username = {
-        format      = "[$user]($style)";
-        show_always = true;
-      };
-
-      rust   = { format = "via [$symbol($version)]($style) "; style = "bold red";    };
-      python = { format = "via [$symbol($version)]($style) "; style = "bold yellow"; };
-      golang = { format = "via [$symbol($version)]($style) "; style = "bold cyan";   };
-      nodejs = { format = "via [$symbol($version)]($style) "; style = "bold green";  };
-
-      # Disabled language modules
-      buf.disabled        = true;
-      bun.disabled        = true;
-      c.disabled          = true;
-      cmake.disabled      = true;
-      cobol.disabled      = true;
-      crystal.disabled    = true;
-      daml.disabled       = true;
-      dart.disabled       = true;
-      deno.disabled       = true;
-      dotnet.disabled     = true;
-      elixir.disabled     = true;
-      elm.disabled        = true;
-      erlang.disabled     = true;
-      fennel.disabled     = true;
-      gleam.disabled      = true;
-      gradle.disabled     = true;
-      haskell.disabled    = true;
-      haxe.disabled       = true;
-      helm.disabled       = true;
-      java.disabled       = true;
-      julia.disabled      = true;
-      kotlin.disabled     = true;
-      lua.disabled        = true;
-      meson.disabled      = true;
-      nim.disabled        = true;
-      nix_shell.disabled  = true;
-      ocaml.disabled      = true;
-      odin.disabled       = true;
-      opa.disabled        = true;
-      perl.disabled       = true;
-      php.disabled        = true;
-      pulumi.disabled     = true;
-      purescript.disabled = true;
-      quarto.disabled     = true;
-      raku.disabled       = true;
-      red.disabled        = true;
-      rlang.disabled      = true;
-      ruby.disabled       = true;
-      scala.disabled      = true;
-      solidity.disabled   = true;
-      swift.disabled      = true;
-      terraform.disabled  = true;
-      typst.disabled      = true;
-      vagrant.disabled    = true;
-      vlang.disabled      = true;
-      zig.disabled        = true;
+    sessionVariables = {
+      EDITOR = "vim";
+      CLAUDE_PROFILE = context;
     };
-  };
 
-  # ── Shell tools ──────────────────────────────────────────────────────────────
+    # Binaries installed via `cargo install` outside Nix land here
+    sessionPath = ["$HOME/.cargo/bin" "$HOME/.npm-global/bin"];
 
-  programs.direnv = {
-    enable            = true;
-    nix-direnv.enable = true;
-  };
+    packages = with pkgs; [
+      # Fonts — used everywhere for terminal rendering and prompt icons
+      fira-code
+      nerd-fonts.fira-code
 
-  programs.zoxide = {
-    enable                = true;
-    enableZshIntegration  = true;
-    enableBashIntegration = true;
-  };
+      # Home Manager — needed for setup across all profiles and devices
+      pkgs.home-manager
 
-  programs.atuin = {
-    enable                = true;
-    enableZshIntegration  = true;
-    enableBashIntegration = true;
-  };
+      # just — task runner / discoverability layer (`just --list` shows all commands)
+      just
 
-  programs.fzf = {
-    enable                = true;
-    enableZshIntegration  = true;
-    enableBashIntegration = true;
-  };
-
-  # ── Editor ───────────────────────────────────────────────────────────────────
-
-  programs.vim = {
-    enable        = true;
-    defaultEditor = true;
-    settings = {
-      number         = true;
-      relativenumber = true;
-      tabstop        = 2;
-      shiftwidth     = 2;
-      expandtab      = true;
-    };
-    extraConfig = ''
-      syntax on
-      set clipboard=unnamed
-      set ignorecase
-      set smartcase
-    '';
-  };
-
-  # ── SSH ──────────────────────────────────────────────────────────────────────
-  # credential.helper is NOT set here — gui-darwin/gui-linux own that
-
-  programs.ssh = {
-    enable                = true;
-    enableDefaultConfig   = false;
-    includes              = [ "~/.ssh/config.d/*" ];  # work.nix writes stubs here
-    matchBlocks = {
-      "*" = {
-        identityFile   = "~/.ssh/${user.sshKey}";
-        addKeysToAgent = "yes";
-        extraOptions   = lib.optionalAttrs pkgs.stdenv.isDarwin {
-          UseKeychain = "yes";
-        };
-      };
-      "github.com" = {
-        user           = "git";
-        identitiesOnly = true;
-      };
-    };
-  };
-
-  # entryAfter writeBoundary — ~/.ssh must exist (written by HM) before ssh-keygen runs.
-  home.activation.sshKey = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
-    if [ ! -f "$HOME/.ssh/${user.sshKey}" ]; then
-      $DRY_RUN_CMD mkdir -p "$HOME/.ssh"
-      $DRY_RUN_CMD chmod 700 "$HOME/.ssh"
-      $DRY_RUN_CMD ${pkgs.openssh}/bin/ssh-keygen -t ed25519 -C "${user.email}" \
-        -f "$HOME/.ssh/${user.sshKey}" -N ""
-      echo "SSH key generated: ~/.ssh/${user.sshKey}"
-      echo "Add to GitHub: https://github.com/settings/keys"
-      cat "$HOME/.ssh/${user.sshKey}.pub"
-    fi
-  '';
-
-  # Set zsh as the default login shell on non-Darwin (WSL2/Linux).
-  # Adds the Nix-managed zsh to /etc/shells (requires sudo) then calls chsh.
-  # No-ops if the shell is already set correctly.
-  # ── Git ──────────────────────────────────────────────────────────────────────
-
-  programs.git = {
-    enable    = true;
-    userName  = user.name;
-    userEmail = user.email;
-
-    includes = [
-      # self doesn't include submodule contents in the Nix store; use live path instead.
-      # Safe because --impure is already required for user.nix.
-      { path = "${home}/.nix-config/config/git/gitalias/gitalias.txt"; }
+      # CLI essentials
+      jq
+      ripgrep
+      fd
+      bat
+      eza
+      delta
+      lazygit
+      git-lfs
+      wget
+      btop
+      neofetch
     ];
 
-    ignores = [
-      ".DS_Store" ".AppleDouble" ".LSOverride"
-      ".env" ".env.local" "*.env" ".env.*"
-      ".config/secrets/"
-      "*.pyc" "__pycache__/" ".venv/" ".ipynb_checkpoints/"
-      ".direnv/"
-      "node_modules/"
-      ".idea/" ".vscode/"
-      "*.swp" "*.swo"
-      "target/"
-    ];
-
-    extraConfig = {
-      init.defaultBranch    = "main";
-      pull.rebase           = false;
-      push.default          = "simple";
-      push.autoSetupRemote  = true;
-      core.autocrlf         = "input";
-      diff.tool             = "vscode";
-      merge.tool            = "vscode";
-      difftool."vscode".cmd  = "code --wait --diff $LOCAL $REMOTE";
-      mergetool."vscode".cmd = "code --wait $MERGED";
-      # credential.helper intentionally absent — set by gui-darwin or gui-linux
-    };
-  };
-
-  # ── Tool config symlinks ─────────────────────────────────────────────────────
-  # Submodules under config/ are symlinked into HOME so tools find them at the
-  # expected paths. mkOutOfStoreSymlink keeps them live-editable (not copied
-  # into the Nix store), which is required for git-managed tool configs.
-
-  home.file.".claude" = {
-    source = config.lib.file.mkOutOfStoreSymlink
-      "${config.home.homeDirectory}/.nix-config/config/claude";
-  };
-
-  home.file.".copilot" = lib.mkIf (context == "personal") {
-    source = config.lib.file.mkOutOfStoreSymlink
-      "${config.home.homeDirectory}/.nix-config/config/copilot";
-  };
-
-  # ── Submodule remote overrides ───────────────────────────────────────────────
-  # For each entry in user.submodules, wire up a private remote in the
-  # corresponding config/ submodule and check out a tracking branch.
-  # Idempotent — skips if the remote already exists.
-  # entryAfter writeBoundary — submodule dirs must be cloned before we can add remotes.
-  # user.submodules = { claude = "git@github.com:you/private-claude.git"; };
-  home.activation.submoduleOverrides = lib.hm.dag.entryAfter [ "writeBoundary" ] (
-    let
-      submodules = user.submodules or {};
-      nix = "${pkgs.nix}/bin/nix";
-      git = "${pkgs.git}/bin/git";
-      mkOverride = name: url: ''
-        _sm_dir="$HOME/.nix-config/config/${name}"
-        if [ -d "$_sm_dir/.git" ]; then
-          _has_private=$(${git} -C "$_sm_dir" remote get-url private 2>/dev/null && echo yes || echo no)
-          if [ "$_has_private" = "no" ]; then
-            $DRY_RUN_CMD ${git} -C "$_sm_dir" remote add private "${url}"
-            if $DRY_RUN_CMD ${git} -C "$_sm_dir" fetch private; then
-              $DRY_RUN_CMD ${git} -C "$_sm_dir" checkout -b work --track private/main \
-                || ${git} -C "$_sm_dir" checkout work
-              echo "submodule ${name}: private remote configured (${url})"
-            else
-              echo "WARNING: submodule ${name}: fetch from private remote failed."
-              echo "  Ensure your SSH key is added to GitHub, then rerun: home-manager switch --flake ~/.nix-config --impure"
-              $DRY_RUN_CMD ${git} -C "$_sm_dir" remote remove private
-            fi
-          fi
+    activation = {
+      # entryAfter writeBoundary — ~/.ssh must exist (written by HM) before ssh-keygen runs.
+      sshKey = lib.hm.dag.entryAfter ["writeBoundary"] ''
+        if [ ! -f "$HOME/.ssh/${user.sshKey}" ]; then
+          $DRY_RUN_CMD mkdir -p "$HOME/.ssh"
+          $DRY_RUN_CMD chmod 700 "$HOME/.ssh"
+          $DRY_RUN_CMD ${pkgs.openssh}/bin/ssh-keygen -t ed25519 -C "${user.email}" \
+            -f "$HOME/.ssh/${user.sshKey}" -N ""
+          echo "SSH key generated: ~/.ssh/${user.sshKey}"
+          echo "Add to GitHub: https://github.com/settings/keys"
+          cat "$HOME/.ssh/${user.sshKey}.pub"
         fi
       '';
-    in
-      lib.concatStrings (lib.mapAttrsToList mkOverride submodules)
-  );
 
-  home.stateVersion = "23.11";
+      # For each entry in user.submodules, wire up a private remote in the
+      # corresponding config/ submodule and check out a tracking branch.
+      # Idempotent — skips if the remote already exists.
+      # entryAfter writeBoundary — submodule dirs must be cloned before we can add remotes.
+      # user.submodules = { claude = "git@github.com:you/private-claude.git"; };
+      submoduleOverrides = lib.hm.dag.entryAfter ["writeBoundary"] (
+        let
+          submodules = user.submodules or {};
+          git = "${pkgs.git}/bin/git";
+          mkOverride = name: url: ''
+            _sm_dir="$HOME/.nix-config/config/${name}"
+            if [ -d "$_sm_dir/.git" ]; then
+              _has_private=$(${git} -C "$_sm_dir" remote get-url private 2>/dev/null && echo yes || echo no)
+              if [ "$_has_private" = "no" ]; then
+                $DRY_RUN_CMD ${git} -C "$_sm_dir" remote add private "${url}"
+                if $DRY_RUN_CMD ${git} -C "$_sm_dir" fetch private; then
+                  $DRY_RUN_CMD ${git} -C "$_sm_dir" checkout -b work --track private/main \
+                    || ${git} -C "$_sm_dir" checkout work
+                  echo "submodule ${name}: private remote configured (${url})"
+                else
+                  echo "WARNING: submodule ${name}: fetch from private remote failed."
+                  echo "  Ensure your SSH key is added to GitHub, then rerun: home-manager switch --flake ~/.nix-config --impure"
+                  $DRY_RUN_CMD ${git} -C "$_sm_dir" remote remove private
+                fi
+              fi
+            fi
+          '';
+        in
+          lib.concatStrings (lib.mapAttrsToList mkOverride submodules)
+      );
+    };
+
+    # Submodules under config/ are symlinked into HOME so tools find them at the
+    # expected paths. mkOutOfStoreSymlink keeps them live-editable (not copied
+    # into the Nix store), which is required for git-managed tool configs.
+    file = {
+      ".claude" = {
+        source =
+          config.lib.file.mkOutOfStoreSymlink
+          "${config.home.homeDirectory}/.nix-config/config/claude";
+      };
+      ".copilot" = lib.mkIf (context == "personal") {
+        source =
+          config.lib.file.mkOutOfStoreSymlink
+          "${config.home.homeDirectory}/.nix-config/config/copilot";
+      };
+    };
+
+    stateVersion = "23.11";
+  };
+
+  programs = {
+    # ── Shells ────────────────────────────────────────────────────────────────
+
+    zsh = {
+      enable = true;
+      enableCompletion = true;
+      shellAliases = commonAliases;
+      # envExtra → .zshenv (sourced first, before .zshrc). Nix must be on PATH
+      # before tool integrations (atuin, fnm, zoxide) evaluate their init hooks.
+      envExtra = nixProfileInit;
+      initContent =
+        envLocalInit
+        + ''
+          # Word navigation: Alt/Option+arrow. Alacritty with option_as_alt sends
+          # xterm-style sequences on macOS; Linux terminals send the same sequences.
+          bindkey '^[[1;3D' backward-word
+          bindkey '^[[1;3C' forward-word
+          # Home/End keys (also covers Cmd+Left/Right via Alacritty keybindings.toml)
+          bindkey '^[[H' beginning-of-line
+          bindkey '^[[F' end-of-line
+        '';
+    };
+
+    bash = {
+      enable = true;
+      enableCompletion = true;
+      shellAliases = commonAliases;
+      profileExtra = nixProfileInit;
+      initExtra = envLocalInit;
+    };
+
+    # ── Prompt ────────────────────────────────────────────────────────────────
+
+    starship = {
+      enable = true;
+      enableZshIntegration = true;
+      enableBashIntegration = true;
+      settings = {
+        format = "$os$username$hostname$directory$git_branch$git_status$aws$rust$python$golang$nodejs$package$cmd_duration\n$character";
+
+        aws = {
+          format = "[$symbol$region]($style) ";
+          force_display = false;
+          region_aliases = {
+            "us-east-1" = "va";
+            "us-east-2" = "oh";
+            "us-west-1" = "ca";
+            "us-west-2" = "or";
+            "af-south-1" = "cape";
+            "ap-east-1" = "hk";
+            "ap-south-1" = "mum";
+            "ap-south-2" = "hyd";
+            "ap-southeast-1" = "sg";
+            "ap-southeast-2" = "syd";
+            "ap-southeast-3" = "jkt";
+            "ap-southeast-4" = "mel";
+            "ap-southeast-5" = "my";
+            "ap-southeast-6" = "nz";
+            "ap-southeast-7" = "th";
+            "ap-northeast-1" = "tok";
+            "ap-northeast-2" = "kr";
+            "ap-northeast-3" = "osk";
+            "ap-east-2" = "tw";
+            "ca-central-1" = "ca";
+            "ca-west-1" = "cal";
+            "cn-north-1" = "bj";
+            "cn-northwest-1" = "nx";
+            "eu-central-1" = "de";
+            "eu-central-2" = "ch";
+            "eu-north-1" = "se";
+            "eu-south-1" = "it";
+            "eu-south-2" = "es";
+            "eu-west-1" = "ie";
+            "eu-west-2" = "ldn";
+            "eu-west-3" = "fr";
+            "me-central-1" = "ae";
+            "me-south-1" = "bh";
+            "mx-central-1" = "mx";
+            "sa-east-1" = "br";
+            "us-gov-east-1" = "gov-e";
+            "us-gov-west-1" = "gov-w";
+          };
+        };
+
+        character = {
+          success_symbol = "[❯](bold green)";
+          error_symbol = "[❯](bold red)";
+        };
+
+        cmd_duration = {
+          min_time = 2000;
+          format = "took [$duration]($style) ";
+          style = "bold yellow";
+        };
+
+        directory.truncation_length = 3;
+
+        git_branch.symbol = "🌱 ";
+
+        git_status = {
+          ahead = "⇡\${count}";
+          diverged = "⇕⇡\${ahead_count}⇣\${behind_count}";
+          behind = "⇣\${count}";
+        };
+
+        hostname = {
+          ssh_only = false;
+          format = "[@](black)([$ssh_symbol]($style))[$hostname](bold blue) ";
+        };
+
+        os.disabled = false;
+
+        package.format = "[$symbol$version]($style) ";
+
+        username = {
+          format = "[$user]($style)";
+          show_always = true;
+        };
+
+        rust = {
+          format = "via [$symbol($version)]($style) ";
+          style = "bold red";
+        };
+        python = {
+          format = "via [$symbol($version)]($style) ";
+          style = "bold yellow";
+        };
+        golang = {
+          format = "via [$symbol($version)]($style) ";
+          style = "bold cyan";
+        };
+        nodejs = {
+          format = "via [$symbol($version)]($style) ";
+          style = "bold green";
+        };
+
+        # Disabled language modules
+        buf.disabled = true;
+        bun.disabled = true;
+        c.disabled = true;
+        cmake.disabled = true;
+        cobol.disabled = true;
+        crystal.disabled = true;
+        daml.disabled = true;
+        dart.disabled = true;
+        deno.disabled = true;
+        dotnet.disabled = true;
+        elixir.disabled = true;
+        elm.disabled = true;
+        erlang.disabled = true;
+        fennel.disabled = true;
+        gleam.disabled = true;
+        gradle.disabled = true;
+        haskell.disabled = true;
+        haxe.disabled = true;
+        helm.disabled = true;
+        java.disabled = true;
+        julia.disabled = true;
+        kotlin.disabled = true;
+        lua.disabled = true;
+        meson.disabled = true;
+        nim.disabled = true;
+        nix_shell.disabled = true;
+        ocaml.disabled = true;
+        odin.disabled = true;
+        opa.disabled = true;
+        perl.disabled = true;
+        php.disabled = true;
+        pulumi.disabled = true;
+        purescript.disabled = true;
+        quarto.disabled = true;
+        raku.disabled = true;
+        red.disabled = true;
+        rlang.disabled = true;
+        ruby.disabled = true;
+        scala.disabled = true;
+        solidity.disabled = true;
+        swift.disabled = true;
+        terraform.disabled = true;
+        typst.disabled = true;
+        vagrant.disabled = true;
+        vlang.disabled = true;
+        zig.disabled = true;
+      };
+    };
+
+    # ── Shell tools ───────────────────────────────────────────────────────────
+
+    direnv = {
+      enable = true;
+      nix-direnv.enable = true;
+    };
+
+    zoxide = {
+      enable = true;
+      enableZshIntegration = true;
+      enableBashIntegration = true;
+    };
+
+    atuin = {
+      enable = true;
+      enableZshIntegration = true;
+      enableBashIntegration = true;
+    };
+
+    fzf = {
+      enable = true;
+      enableZshIntegration = true;
+      enableBashIntegration = true;
+    };
+
+    # ── Editor ────────────────────────────────────────────────────────────────
+
+    vim = {
+      enable = true;
+      defaultEditor = true;
+      settings = {
+        number = true;
+        relativenumber = true;
+        tabstop = 2;
+        shiftwidth = 2;
+        expandtab = true;
+      };
+      extraConfig = ''
+        syntax on
+        set clipboard=unnamed
+        set ignorecase
+        set smartcase
+      '';
+    };
+
+    # ── SSH ───────────────────────────────────────────────────────────────────
+    # credential.helper is NOT set here — gui-darwin/gui-linux own that
+
+    ssh = {
+      enable = true;
+      enableDefaultConfig = false;
+      includes = ["~/.ssh/config.d/*"]; # work.nix writes stubs here
+      matchBlocks = {
+        "*" = {
+          identityFile = "~/.ssh/${user.sshKey}";
+          addKeysToAgent = "yes";
+          extraOptions = lib.optionalAttrs pkgs.stdenv.isDarwin {
+            UseKeychain = "yes";
+          };
+        };
+        "github.com" = {
+          user = "git";
+          identitiesOnly = true;
+        };
+      };
+    };
+
+    # ── Git ───────────────────────────────────────────────────────────────────
+
+    git = {
+      enable = true;
+      userName = user.name;
+      userEmail = user.email;
+
+      includes = [
+        # self doesn't include submodule contents in the Nix store; use live path instead.
+        # Safe because --impure is already required for user.nix.
+        {path = "${homeDir}/.nix-config/config/git/gitalias/gitalias.txt";}
+      ];
+
+      ignores = [
+        ".DS_Store"
+        ".AppleDouble"
+        ".LSOverride"
+        ".env"
+        ".env.local"
+        "*.env"
+        ".env.*"
+        ".config/secrets/"
+        "*.pyc"
+        "__pycache__/"
+        ".venv/"
+        ".ipynb_checkpoints/"
+        ".direnv/"
+        "node_modules/"
+        ".idea/"
+        ".vscode/"
+        "*.swp"
+        "*.swo"
+        "target/"
+      ];
+
+      extraConfig = {
+        init.defaultBranch = "main";
+        pull.rebase = false;
+        push.default = "simple";
+        push.autoSetupRemote = true;
+        core.autocrlf = "input";
+        diff.tool = "vscode";
+        merge.tool = "vscode";
+        difftool."vscode".cmd = "code --wait --diff $LOCAL $REMOTE";
+        mergetool."vscode".cmd = "code --wait $MERGED";
+        # credential.helper intentionally absent — set by gui-darwin or gui-linux
+      };
+    };
+  };
 }

--- a/modules/dev.nix
+++ b/modules/dev.nix
@@ -1,27 +1,32 @@
-{ config, pkgs, lib, system, user, ... }:
-
-let
+{
+  pkgs,
+  lib,
+  system,
+  user,
+  ...
+}: let
   # QMK is pinned on x86_64 to avoid build failures on unstable
   qmkPackage =
-    if lib.strings.hasPrefix "x86_64" system then
-      let
-        pinnedPkgs = import (builtins.fetchTarball {
-          url    = "https://github.com/NixOS/nixpkgs/archive/0c408a087b4751c887e463e3848512c12017be25.tar.gz";
-          sha256 = "049l2w7sngxb354kkrvaigzkkiz5073y7s176xdvqgm4gyzp05dw";
-        }) { inherit system; };
-      in pinnedPkgs.qmk
+    if lib.strings.hasPrefix "x86_64" system
+    then let
+      pinnedPkgs = import (builtins.fetchTarball {
+        url = "https://github.com/NixOS/nixpkgs/archive/0c408a087b4751c887e463e3848512c12017be25.tar.gz";
+        sha256 = "049l2w7sngxb354kkrvaigzkkiz5073y7s176xdvqgm4gyzp05dw";
+      }) {inherit system;};
+    in
+      pinnedPkgs.qmk
     else pkgs.qmk;
-in
-{
+in {
   home.packages = with pkgs; [
     # Rust — stable + nightly both preinstalled via rust-overlay so switching is instant.
     # Switch with: rustup default nightly / rustup default stable / cargo +nightly
     # rust-analyzer lives only in nightly to avoid the proc-macro-srv path conflict.
     (rust-bin.stable.latest.default.override {
-      extensions = [ "rust-src" "rustfmt" "clippy" ];
-      targets    = if pkgs.stdenv.isDarwin
-        then [ "x86_64-apple-darwin"      "aarch64-apple-darwin"      ]
-        else [ "x86_64-unknown-linux-gnu"  "aarch64-unknown-linux-gnu" ];
+      extensions = ["rust-src" "rustfmt" "clippy"];
+      targets =
+        if pkgs.stdenv.isDarwin
+        then ["x86_64-apple-darwin" "aarch64-apple-darwin"]
+        else ["x86_64-unknown-linux-gnu" "aarch64-unknown-linux-gnu"];
     })
     # nixpkgs standalone rust-analyzer — avoids wasm-component-ld collision with stable rust-std
     rust-analyzer
@@ -58,7 +63,7 @@ in
   # Claude Code — not yet in nixpkgs; installed globally via npm
   # Requires npm on PATH — run manually if activation skips it:
   #   npm install -g @anthropic-ai/claude-code
-  home.activation.claudeCode = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+  home.activation.claudeCode = lib.hm.dag.entryAfter ["writeBoundary"] ''
     if [ -z "$DRY_RUN_CMD" ] && ! command -v claude &>/dev/null && command -v npm &>/dev/null; then
       export PATH="$HOME/.nix-profile/bin:$HOME/.npm-global/bin:$PATH"
       if [ "$(id -u)" -eq 0 ]; then
@@ -75,26 +80,28 @@ in
   '';
 
   # fnm shell init — appended after base shell config
-  programs.zsh.initContent = lib.mkAfter ''
-    eval "$(fnm env --use-on-cd)"
-  '';
-
-  programs.bash.initExtra = lib.mkAfter ''
-    eval "$(fnm env --use-on-cd)"
-  '';
-
-  programs.tmux = {
-    enable       = true;
-    keyMode      = "vi";
-    mouse        = true;
-    terminal     = "screen-256color";
-    historyLimit = 10000;
-    extraConfig  = ''
-      set -g status-style bg=black,fg=white
-      set -g status-left  "#[fg=green]#S "
-      set -g status-right "#[fg=yellow]%H:%M"
-      bind | split-window -h
-      bind - split-window -v
+  programs = {
+    zsh.initContent = lib.mkAfter ''
+      eval "$(fnm env --use-on-cd)"
     '';
+
+    bash.initExtra = lib.mkAfter ''
+      eval "$(fnm env --use-on-cd)"
+    '';
+
+    tmux = {
+      enable = true;
+      keyMode = "vi";
+      mouse = true;
+      terminal = "screen-256color";
+      historyLimit = 10000;
+      extraConfig = ''
+        set -g status-style bg=black,fg=white
+        set -g status-left  "#[fg=green]#S "
+        set -g status-right "#[fg=yellow]%H:%M"
+        bind | split-window -h
+        bind - split-window -v
+      '';
+    };
   };
 }

--- a/modules/dev.nix
+++ b/modules/dev.nix
@@ -50,6 +50,7 @@ in
 
     # Dev tools
     gh
+    pre-commit
     tmux
     qmkPackage
   ];

--- a/modules/gui-darwin.nix
+++ b/modules/gui-darwin.nix
@@ -1,34 +1,11 @@
-{ pkgs, lib, ... }:
-
 {
+  pkgs,
+  lib,
+  ...
+}: {
   home.packages = with pkgs; [
     obsidian
   ];
-
-  programs.alacritty = {
-    enable   = true;
-    settings = {
-      window = {
-        opacity       = 0.9;
-        decorations   = "buttonless";
-        option_as_alt = "Both";
-      };
-      font = {
-        size          = 14;
-        normal.family = "Fira Code";
-      };
-      colors = {
-        primary = {
-          background = "#1e1e1e";
-          foreground = "#d4d4d4";
-        };
-      };
-      general.import = [
-        "rose-pine/dist/rose-pine.toml"
-        "~/.config/alacritty/keybindings.toml"
-      ];
-    };
-  };
 
   # Raw TOML for Cmd+arrow bindings. Written via home.file.text so the
   # \uXXXX sequences are literal text in the TOML file (valid TOML Unicode escapes).
@@ -36,30 +13,55 @@
     [[keyboard.bindings]]
     key = "Left"
     mods = "Command"
-    chars = "\u0001"
-    
+    chars = ""
+
     [[keyboard.bindings]]
     key = "Right"
     mods = "Command"
-    chars = "\u0005"
-    
+    chars = ""
+
     [[keyboard.bindings]]
     key = "Back"
     mods = "Command"
-    chars = "\u0015"
-    
+    chars = ""
+
     [[keyboard.bindings]]
     key = "Left"
     mods = "Option"
-    chars = "\u001bb"
-    
+    chars = "b"
+
     [[keyboard.bindings]]
     key = "Right"
     mods = "Option"
-    chars = "\u001bf"
+    chars = "f"
   '';
 
-  programs.vscode.enable = true;
-
-  programs.git.extraConfig.credential.helper = lib.mkForce "osxkeychain";
+  programs = {
+    alacritty = {
+      enable = true;
+      settings = {
+        window = {
+          opacity = 0.9;
+          decorations = "buttonless";
+          option_as_alt = "Both";
+        };
+        font = {
+          size = 14;
+          normal.family = "Fira Code";
+        };
+        colors = {
+          primary = {
+            background = "#1e1e1e";
+            foreground = "#d4d4d4";
+          };
+        };
+        general.import = [
+          "rose-pine/dist/rose-pine.toml"
+          "~/.config/alacritty/keybindings.toml"
+        ];
+      };
+    };
+    vscode.enable = true;
+    git.extraConfig.credential.helper = lib.mkForce "osxkeychain";
+  };
 }

--- a/modules/gui-darwin.nix
+++ b/modules/gui-darwin.nix
@@ -7,8 +7,10 @@
     obsidian
   ];
 
-  # Raw TOML for Cmd+arrow bindings. Written via home.file.text so the
-  # \uXXXX sequences are literal text in the TOML file (valid TOML Unicode escapes).
+  # Raw TOML for Cmd/Option+arrow bindings. The chars values are literal
+  # control-character bytes (Ctrl-A, Ctrl-E, Ctrl-U, ESC-b, ESC-f) — Nix
+  # heredoc strings do not support \u escapes, so the bytes are embedded
+  # directly. Alacritty reads chars as a raw byte sequence, not TOML escapes.
   home.file.".config/alacritty/keybindings.toml".text = ''
     [[keyboard.bindings]]
     key = "Left"

--- a/modules/gui-linux.nix
+++ b/modules/gui-linux.nix
@@ -1,34 +1,38 @@
-{ pkgs, lib, ... }:
-
 {
+  pkgs,
+  lib,
+  ...
+}: {
   home.packages = with pkgs; [
     obsidian
   ];
 
-  programs.alacritty = {
-    enable   = true;
-    settings = {
-      window = {
-        opacity     = 0.9;
-        decorations = "none";
-      };
-      font = {
-        size              = 14;
-        normal.family     = "Fira Code";
-      };
-      colors = {
-        primary = {
-          background = "#1e1e1e";
-          foreground = "#d4d4d4";
+  programs = {
+    alacritty = {
+      enable = true;
+      settings = {
+        window = {
+          opacity = 0.9;
+          decorations = "none";
+        };
+        font = {
+          size = 14;
+          normal.family = "Fira Code";
+        };
+        colors = {
+          primary = {
+            background = "#1e1e1e";
+            foreground = "#d4d4d4";
+          };
         };
       };
     };
+
+    vscode.enable = true;
+
+    # credential.helper for Linux GUI machines
+    git.extraConfig.credential.helper = lib.mkForce "store";
   };
-
-  programs.vscode.enable = true;
-
-  # credential.helper for Linux GUI machines
-  programs.git.extraConfig.credential.helper = lib.mkForce "store";
 
   # Stubs for future NixOS desktop services — uncomment when running bare NixOS
   # services.picom.enable = true;

--- a/modules/server.nix
+++ b/modules/server.nix
@@ -1,6 +1,4 @@
-{ pkgs, lib, ... }:
-
-{
+{pkgs, ...}: {
   home.packages = with pkgs; [
     rsync
     tree
@@ -10,12 +8,12 @@
   ];
 
   programs.tmux = {
-    enable       = true;
-    keyMode      = "vi";
-    mouse        = true;
-    terminal     = "screen-256color";
-    historyLimit = 50000;  # larger than dev — server sessions are long-lived
-    extraConfig  = ''
+    enable = true;
+    keyMode = "vi";
+    mouse = true;
+    terminal = "screen-256color";
+    historyLimit = 50000; # larger than dev — server sessions are long-lived
+    extraConfig = ''
       set -g status-style bg=black,fg=white
       set -g status-left  "#[fg=green]#S "
       set -g status-right "#[fg=yellow]%H:%M"

--- a/modules/work.nix
+++ b/modules/work.nix
@@ -1,50 +1,58 @@
-{ config, pkgs, lib, user, ... }:
-
 {
+  pkgs,
+  lib,
+  user,
+  ...
+}: {
   # AWS tools — present on all work tiers (minimal, dev, server)
-  home.packages = with pkgs; [
-    awscli2
-    aws-vault
-  ];
+  home = {
+    packages = with pkgs; [
+      awscli2
+      aws-vault
+    ];
 
-  # Git identity for work — overrides the personal identity set in base.nix
-  programs.git.userName  = lib.mkForce user.work.name;
-  programs.git.userEmail = lib.mkForce user.work.email;
+    # Corporate root CA — Linux only; macOS uses the system keychain
+    # The PEM file is never committed. Place it manually at ~/.certs/corporate.pem.
+    # See docs/bootstrap.md for how to obtain it.
+    #
+    # combined-ca-bundle.crt = system public CAs + corporate CAs. All vars point here
+    # so nix tools, curl, AWS CLI, and Python all trust both public and internal endpoints.
+    # NODE_EXTRA_CA_CERTS is append-only (Node bundles its own CAs), so corp.pem suffices.
+    sessionVariables = lib.mkIf (!pkgs.stdenv.isDarwin) {
+      SSL_CERT_FILE = "$HOME/.certs/combined-ca-bundle.crt";
+      NIX_SSL_CERT_FILE = "$HOME/.certs/combined-ca-bundle.crt";
+      REQUESTS_CA_BUNDLE = "$HOME/.certs/combined-ca-bundle.crt";
+      AWS_CA_BUNDLE = "$HOME/.certs/combined-ca-bundle.crt";
+      NODE_EXTRA_CA_CERTS = "$HOME/.certs/corporate.pem";
+    };
 
-  # Corporate root CA — Linux only; macOS uses the system keychain
-  # The PEM file is never committed. Place it manually at ~/.certs/corporate.pem.
-  # See docs/bootstrap.md for how to obtain it.
-  #
-  # combined-ca-bundle.crt = system public CAs + corporate CAs. All vars point here
-  # so nix tools, curl, AWS CLI, and Python all trust both public and internal endpoints.
-  # NODE_EXTRA_CA_CERTS is append-only (Node bundles its own CAs), so corp.pem suffices.
-  home.sessionVariables = lib.mkIf (!pkgs.stdenv.isDarwin) {
-    SSL_CERT_FILE       = "$HOME/.certs/combined-ca-bundle.crt";
-    NIX_SSL_CERT_FILE   = "$HOME/.certs/combined-ca-bundle.crt";
-    REQUESTS_CA_BUNDLE  = "$HOME/.certs/combined-ca-bundle.crt";
-    AWS_CA_BUNDLE       = "$HOME/.certs/combined-ca-bundle.crt";
-    NODE_EXTRA_CA_CERTS = "$HOME/.certs/corporate.pem";
+    # Linux only — macOS trusts corporate certs via system keychain, not this bundle
+    activation.mergeCorporateCerts =
+      lib.mkIf (!pkgs.stdenv.isDarwin)
+      (lib.hm.dag.entryAfter ["writeBoundary"] ''
+        $DRY_RUN_CMD mkdir -p "$HOME/.certs"
+        if [ -f "$HOME/.certs/corporate.pem" ]; then
+          _bundle=$(cat /etc/ssl/certs/ca-certificates.crt "$HOME/.certs/corporate.pem")
+          $DRY_RUN_CMD sh -c 'printf "%s" "$1" > "$2"' -- "$_bundle" \
+            "$HOME/.certs/combined-ca-bundle.crt"
+        else
+          echo "WARNING: ~/.certs/corporate.pem not found — see docs/bootstrap.md"
+        fi
+      '');
+
+    # Work SSH stubs — included via the `Include ~/.ssh/config.d/*` in base.nix programs.ssh
+    file.".ssh/config.d/work".text = ''
+      # Work VPN / jump host — fill in hostnames before use
+      # Host work-jump
+      #   HostName jump.corp.example.com
+      #   User ${user.username}
+      #   IdentityFile ~/.ssh/${user.sshKey}
+    '';
   };
 
-  # Linux only — macOS trusts corporate certs via system keychain, not this bundle
-  home.activation.mergeCorporateCerts = lib.mkIf (!pkgs.stdenv.isDarwin)
-    (lib.hm.dag.entryAfter [ "writeBoundary" ] ''
-      $DRY_RUN_CMD mkdir -p "$HOME/.certs"
-      if [ -f "$HOME/.certs/corporate.pem" ]; then
-        _bundle=$(cat /etc/ssl/certs/ca-certificates.crt "$HOME/.certs/corporate.pem")
-        $DRY_RUN_CMD sh -c 'printf "%s" "$1" > "$2"' -- "$_bundle" \
-          "$HOME/.certs/combined-ca-bundle.crt"
-      else
-        echo "WARNING: ~/.certs/corporate.pem not found — see docs/bootstrap.md"
-      fi
-    '');
-
-  # Work SSH stubs — included via the `Include ~/.ssh/config.d/*` in base.nix programs.ssh
-  home.file.".ssh/config.d/work".text = ''
-    # Work VPN / jump host — fill in hostnames before use
-    # Host work-jump
-    #   HostName jump.corp.example.com
-    #   User ${user.username}
-    #   IdentityFile ~/.ssh/${user.sshKey}
-  '';
+  # Git identity for work — overrides the personal identity set in base.nix
+  programs.git = {
+    userName = lib.mkForce user.work.name;
+    userEmail = lib.mkForce user.work.email;
+  };
 }

--- a/system/darwin.nix
+++ b/system/darwin.nix
@@ -1,9 +1,5 @@
-{ pkgs, system, user, ... }:
-
-{
-  nix.settings.experimental-features = [ "nix-command" "flakes" ];
-
-  system.primaryUser = user.username;
+{user, ...}: {
+  nix.settings.experimental-features = ["nix-command" "flakes"];
 
   # Define user for Home Manager compatibility
   users.users.${user.username} = {
@@ -16,36 +12,6 @@
 
   # Enable TouchID for sudo
   security.pam.services.sudo_local.touchIdAuth = true;
-
-  system.defaults = {
-    NSGlobalDomain = {
-      AppleInterfaceStyle = "Dark";
-      AppleShowAllExtensions = true;
-      ApplePressAndHoldEnabled = false;
-      KeyRepeat = 6;
-      InitialKeyRepeat = 15;
-      "com.apple.mouse.tapBehavior" = 1;
-    };
-    dock = {
-      autohide = false;
-      show-recents = false;
-      launchanim = true;
-      mru-spaces = false;
-      orientation = "bottom";
-      tilesize = 48;
-    };
-    finder = {
-      AppleShowAllExtensions = true;
-      AppleShowAllFiles = true;
-      CreateDesktop = false;
-      FXPreferredViewStyle = "clmv";
-      NewWindowTarget = "Home";
-      ShowPathbar = true;
-    };
-    loginwindow.LoginwindowText = "May the odds be ever in your favor.";
-    menuExtraClock.ShowSeconds = true;
-    screensaver.askForPasswordDelay = 10;
-  };
 
   homebrew = {
     enable = true;
@@ -63,5 +29,39 @@
     ];
   };
 
-  system.stateVersion = 6;
+  system = {
+    primaryUser = user.username;
+
+    defaults = {
+      NSGlobalDomain = {
+        AppleInterfaceStyle = "Dark";
+        AppleShowAllExtensions = true;
+        ApplePressAndHoldEnabled = false;
+        KeyRepeat = 6;
+        InitialKeyRepeat = 15;
+        "com.apple.mouse.tapBehavior" = 1;
+      };
+      dock = {
+        autohide = false;
+        show-recents = false;
+        launchanim = true;
+        mru-spaces = false;
+        orientation = "bottom";
+        tilesize = 48;
+      };
+      finder = {
+        AppleShowAllExtensions = true;
+        AppleShowAllFiles = true;
+        CreateDesktop = false;
+        FXPreferredViewStyle = "clmv";
+        NewWindowTarget = "Home";
+        ShowPathbar = true;
+      };
+      loginwindow.LoginwindowText = "May the odds be ever in your favor.";
+      menuExtraClock.ShowSeconds = true;
+      screensaver.askForPasswordDelay = 10;
+    };
+
+    stateVersion = 6;
+  };
 }

--- a/system/nixos.nix
+++ b/system/nixos.nix
@@ -1,13 +1,15 @@
-{ pkgs, system, user, ... }:
-
 {
-  nix.settings.experimental-features = [ "nix-command" "flakes" ];
+  pkgs,
+  user,
+  ...
+}: {
+  nix.settings.experimental-features = ["nix-command" "flakes"];
 
   users.users.${user.username} = {
     isNormalUser = true;
-    description  = user.username;
-    extraGroups  = [ "wheel" "networkmanager" ];
-    shell        = pkgs.zsh;
+    description = user.username;
+    extraGroups = ["wheel" "networkmanager"];
+    shell = pkgs.zsh;
   };
 
   programs.zsh.enable = true;


### PR DESCRIPTION
Closes #3, closes #7.

## Summary

- **CI** (`.github/workflows/check.yml`): dynamic profile matrix discovery via \`nix eval\`, full Linux/Darwin profile builds, 4 named lint jobs — runs on push to \`main\`, all PRs, and manual dispatch
- **Security** (`.github/workflows/security.yml`): gitleaks secret scan — runs on every push to every branch and all PRs
- **Pre-commit** (`.pre-commit-config.yaml`): hygiene hooks, alejandra (auto-format), gitleaks, markdownlint on \`docs/\`
- **\`modules/dev.nix\`**: add \`pre-commit\` to \`home.packages\` — available after \`home-manager switch\`, no separate install needed
- **\`docs/bootstrap.md\`**: add step 9 (pre-commit install); fix missing \`--impure\` on macOS \`darwin-rebuild switch\`

## CI jobs

| Job | Runner | Notes |
|-----|--------|-------|
| \`get-profiles\` | ubuntu | Discovers all profiles via \`nix eval\`; feeds both matrices |
| \`flake-check\` | ubuntu | \`nix flake check --impure\` + validates \`user.nix.example\` |
| \`build-linux\` | ubuntu (×16) | All \`homeConfigurations\`; QEMU + \`extra-platforms = aarch64-linux\` for aarch64 |
| \`build-darwin\` | macos-14 (×4) | All \`darwinConfigurations\`; x86_64 configs built via Rosetta 2 on Apple Silicon runners |
| \`lint-alejandra/statix/deadnix/markdownlint\` | ubuntu | 4 parallel jobs — each named independently in PR status |

Secret scanning runs in the separate \`Security\` workflow, not \`CI\`, so it can trigger on every push without coupling to the heavier build matrix.

## Nix actions

All jobs use \`cachix/install-nix-action@v31\` (official nixos.org installer) and \`nix-community/cache-nix-action@v7\` (GHA store snapshot cache, no external accounts required). No DeterminateSystems commercial tooling.

## CI trigger design

- \`push: branches: [main]\` — run CI on merge to keep the main badge meaningful
- \`pull_request\` — run CI on all PRs (covers feature branch validation)
- \`workflow_dispatch\` — manual trigger for badge and ad-hoc runs

Feature branch pushes without an open PR intentionally do not trigger the build matrix (saves runner minutes; lint + secret scan still run via the \`Security\` workflow's unrestricted push trigger).

## Pre-commit hooks

\`statix\` and \`deadnix\` are CI-only — neither ships a pre-commit manifest or is worth blocking every local commit. alejandra uses the upstream hook (no Nix required for contributors).

## Notes

- New profiles added to \`flake.nix\` are automatically picked up by CI — no workflow changes needed
- NixOS support tracked separately in issue #5

Co-Authored-By: Claude <noreply@anthropic.com>