### PR TITLE
fix: bugs + code maintainability cleanup

### DIFF
--- a/justfile
+++ b/justfile
@@ -8,7 +8,7 @@ switch PROFILE="personal":
 
 # Apply nix-darwin config (macOS) — PROFILE=personal-darwin or PROFILE=work-darwin
 rebuild PROFILE="personal-darwin":
-    sudo darwin-rebuild switch --flake ~/.nix-config#{{PROFILE}}
+    sudo darwin-rebuild switch --flake ~/.nix-config#{{PROFILE}} --impure
 
 # Update all flake inputs
 update:

--- a/modules/base.nix
+++ b/modules/base.nix
@@ -8,8 +8,6 @@
 }: let
   homeDir = config.home.homeDirectory;
 
-  commonAliases = {};
-
   # Both paths are tried: single-user Nix (common on WSL2/macOS standalone) sources
   # ~/.nix-profile/...; multi-user Nix daemon sources /nix/var/nix/profiles/...
   # Only the installed variant will exist; the other source is a no-op.
@@ -144,7 +142,6 @@ in {
     zsh = {
       enable = true;
       enableCompletion = true;
-      shellAliases = commonAliases;
       # envExtra → .zshenv (sourced first, before .zshrc). Nix must be on PATH
       # before tool integrations (atuin, fnm, zoxide) evaluate their init hooks.
       envExtra = nixProfileInit;
@@ -164,7 +161,6 @@ in {
     bash = {
       enable = true;
       enableCompletion = true;
-      shellAliases = commonAliases;
       profileExtra = nixProfileInit;
       initExtra = envLocalInit;
     };
@@ -432,10 +428,7 @@ in {
         push.default = "simple";
         push.autoSetupRemote = true;
         core.autocrlf = "input";
-        diff.tool = "vscode";
-        merge.tool = "vscode";
-        difftool."vscode".cmd = "code --wait --diff $LOCAL $REMOTE";
-        mergetool."vscode".cmd = "code --wait $MERGED";
+        # diff.tool and merge.tool are set by gui-darwin/gui-linux (where `code` is available)
         # credential.helper intentionally absent — set by gui-darwin or gui-linux
       };
     };

--- a/modules/dev.nix
+++ b/modules/dev.nix
@@ -5,7 +5,22 @@
   user,
   ...
 }: let
-  # QMK is pinned on x86_64 to avoid build failures on unstable
+  tmuxBase = {
+    enable = true;
+    keyMode = "vi";
+    mouse = true;
+    terminal = "screen-256color";
+    extraConfig = ''
+      set -g status-style bg=black,fg=white
+      set -g status-left  "#[fg=green]#S "
+      set -g status-right "#[fg=yellow]%H:%M"
+      bind | split-window -h
+      bind - split-window -v
+    '';
+  };
+
+  # QMK is pinned on x86_64 to a known-good nixpkgs commit (2026-06) due to build
+  # failures on nixpkgs-unstable. Unpin when qmk builds cleanly on unstable again.
   qmkPackage =
     if lib.strings.hasPrefix "x86_64" system
     then let
@@ -49,7 +64,8 @@ in {
     python3Packages.jupyterlab
     python3Packages.ipython
 
-    # AWS
+    # AWS — also declared in work.nix for work-minimal/server tiers that don't include dev.
+    # Nix deduplicates; both declarations are intentional.
     awscli2
     aws-vault
 
@@ -89,19 +105,6 @@ in {
       eval "$(fnm env --use-on-cd)"
     '';
 
-    tmux = {
-      enable = true;
-      keyMode = "vi";
-      mouse = true;
-      terminal = "screen-256color";
-      historyLimit = 10000;
-      extraConfig = ''
-        set -g status-style bg=black,fg=white
-        set -g status-left  "#[fg=green]#S "
-        set -g status-right "#[fg=yellow]%H:%M"
-        bind | split-window -h
-        bind - split-window -v
-      '';
-    };
+    tmux = tmuxBase // {historyLimit = 10000;};
   };
 }

--- a/modules/gui-darwin.nix
+++ b/modules/gui-darwin.nix
@@ -8,9 +8,13 @@
   ];
 
   # Raw TOML for Cmd/Option+arrow bindings. The chars values are literal
-  # control-character bytes (Ctrl-A, Ctrl-E, Ctrl-U, ESC-b, ESC-f) — Nix
-  # heredoc strings do not support \u escapes, so the bytes are embedded
-  # directly. Alacritty reads chars as a raw byte sequence, not TOML escapes.
+  # control-character bytes — Nix heredoc strings do not support \u escapes,
+  # so the bytes are embedded directly. Alacritty reads chars as a raw byte
+  # sequence, not TOML escapes. Byte identities:
+  #   Cmd+Left  → 0x01 (Ctrl-A) = readline beginning-of-line
+  #   Cmd+Right → 0x05 (Ctrl-E) = readline end-of-line
+  #   Cmd+Back  → 0x15 (Ctrl-U) = readline kill-to-beginning-of-line
+  #   Opt+Left/Right → ESC b / ESC f = readline backward/forward-word
   home.file.".config/alacritty/keybindings.toml".text = ''
     [[keyboard.bindings]]
     key = "Left"
@@ -64,6 +68,12 @@
       };
     };
     vscode.enable = true;
-    git.extraConfig.credential.helper = lib.mkForce "osxkeychain";
+    git.extraConfig = {
+      credential.helper = lib.mkForce "osxkeychain";
+      diff.tool = "vscode";
+      merge.tool = "vscode";
+      difftool."vscode".cmd = "code --wait --diff $LOCAL $REMOTE";
+      mergetool."vscode".cmd = "code --wait $MERGED";
+    };
   };
 }

--- a/modules/gui-linux.nix
+++ b/modules/gui-linux.nix
@@ -31,12 +31,12 @@
     vscode.enable = true;
 
     # credential.helper for Linux GUI machines
-    git.extraConfig.credential.helper = lib.mkForce "store";
+    git.extraConfig = {
+      credential.helper = lib.mkForce "store";
+      diff.tool = "vscode";
+      merge.tool = "vscode";
+      difftool."vscode".cmd = "code --wait --diff $LOCAL $REMOTE";
+      mergetool."vscode".cmd = "code --wait $MERGED";
+    };
   };
-
-  # Stubs for future NixOS desktop services — uncomment when running bare NixOS
-  # services.picom.enable = true;
-  # services.dunst.enable = true;
-  # programs.rofi.enable  = true;
-  # programs.waybar.enable = true;
 }

--- a/modules/server.nix
+++ b/modules/server.nix
@@ -1,4 +1,18 @@
-{pkgs, ...}: {
+{pkgs, ...}: let
+  tmuxBase = {
+    enable = true;
+    keyMode = "vi";
+    mouse = true;
+    terminal = "screen-256color";
+    extraConfig = ''
+      set -g status-style bg=black,fg=white
+      set -g status-left  "#[fg=green]#S "
+      set -g status-right "#[fg=yellow]%H:%M"
+      bind | split-window -h
+      bind - split-window -v
+    '';
+  };
+in {
   home.packages = with pkgs; [
     rsync
     tree
@@ -7,20 +21,15 @@
     # tmux package provided by programs.tmux below
   ];
 
-  programs.tmux = {
-    enable = true;
-    keyMode = "vi";
-    mouse = true;
-    terminal = "screen-256color";
-    historyLimit = 50000; # larger than dev — server sessions are long-lived
-    extraConfig = ''
-      set -g status-style bg=black,fg=white
-      set -g status-left  "#[fg=green]#S "
-      set -g status-right "#[fg=yellow]%H:%M"
-      bind | split-window -h
-      bind - split-window -v
-      # Persist sessions across disconnect
-      set -g @continuum-restore 'on'
-    '';
-  };
+  programs.tmux =
+    tmuxBase
+    // {
+      historyLimit = 50000; # larger than dev — server sessions are long-lived
+      extraConfig =
+        tmuxBase.extraConfig
+        + ''
+          # Persist sessions across disconnect
+          set -g @continuum-restore 'on'
+        '';
+    };
 }

--- a/modules/work.nix
+++ b/modules/work.nix
@@ -4,7 +4,9 @@
   user,
   ...
 }: {
-  # AWS tools — present on all work tiers (minimal, dev, server)
+  # AWS tools — present on all work tiers (minimal, dev, server).
+  # Also declared in dev.nix for personal-dev profiles; Nix deduplicates.
+  # Kept here so work-minimal and work-server get AWS without the full dev tier.
   home = {
     packages = with pkgs; [
       awscli2


### PR DESCRIPTION
## Summary

- Fixes a functional bug in `justfile` (`rebuild` was missing `--impure`)
- Moves `vscode` difftool config to GUI-only modules (was silently broken on `minimal`/`server` profiles where `code` is not on PATH)
- Removes dead code and clarifies maintainability-confusing patterns across modules

## Changes

### Bug fixes

- **`justfile`** — `rebuild` recipe now passes `--impure` to `darwin-rebuild switch` (required; same reason as `home-manager switch`)
- **`base.nix`** — removed `vscode` as `diff.tool`/`merge.tool` (unconditional; breaks non-GUI profiles); moved to `gui-darwin.nix` and `gui-linux.nix` where `code` is guaranteed on PATH

### Code cleanup

- **`base.nix`** — removed dead `commonAliases = {}` variable
- **`gui-linux.nix`** — removed commented-out NixOS desktop service stubs (picom/dunst/rofi/waybar); tracked in #5
- **`dev.nix` + `server.nix`** — extracted shared `tmuxBase` let-binding; only `historyLimit` and the continuum line differ between profiles
- **`dev.nix`** — QMK pin comment now includes date (2026-06) and unpin guidance
- **`dev.nix` + `work.nix`** — clarifying comments for intentional AWS tool duplication (Nix deduplicates; work-minimal needs it without the full dev tier)
- **`gui-darwin.nix`** — alacritty keybindings comment now names each embedded control byte (0x01/0x05/0x15)

## Test plan

- [ ] `nix flake check --impure` passes
- [ ] `pre-commit run --all-files` clean (alejandra, statix, deadnix, markdownlint)
- [ ] CI green on push

## Related issues

Identified during audit for #11, #4, #12.

Co-Authored-By: Claude <noreply@anthropic.com>