### PR TITLE
docs: public-facing polish — README, troubleshooting, contributor workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,52 @@
+name: Bug report
+description: Something isn't working in the framework
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug. Please fill in as much detail as you can.
+
+  - type: dropdown
+    id: platform
+    attributes:
+      label: Platform
+      options:
+        - macOS (nix-darwin)
+        - Linux
+        - WSL2
+    validations:
+      required: true
+
+  - type: input
+    id: profile
+    attributes:
+      label: Profile
+      description: Which profile were you applying? (e.g. `personal`, `work-darwin-aarch64`)
+      placeholder: personal
+    validations:
+      required: true
+
+  - type: textarea
+    id: command
+    attributes:
+      label: Command used
+      description: The exact command you ran
+      render: sh
+    validations:
+      required: true
+
+  - type: textarea
+    id: error
+    attributes:
+      label: Error output
+      description: Full error output, including any Nix trace
+      render: text
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Anything else that might be relevant (Nix version, OS version, recent changes)

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,42 @@
+name: Feature request
+description: Suggest an improvement to the framework (not personal tool preferences)
+labels: [enhancement]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Before opening a feature request, consider whether this is a framework improvement (welcome here)
+        or a personal preference (better suited to your own fork). See [CONTRIBUTING.md](../../CONTRIBUTING.md) for the distinction.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: Describe the gap or pain point in the current framework
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed approach
+      description: How would you implement this? What would change in flake.nix, a module, or docs?
+    validations:
+      required: true
+
+  - type: dropdown
+    id: type
+    attributes:
+      label: Is this framework or personal preference?
+      description: Framework improvements (module system, CI, helpers) belong here. Personal tool choices belong in your fork.
+      options:
+        - Framework improvement (benefits all adopters)
+        - Personal preference (better as a fork)
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: What other approaches did you consider?

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+## Summary
+
+<!-- What does this PR change and why? -->
+
+## Checklist
+
+- [ ] `just check` passes (`nix flake check --impure`)
+- [ ] `pre-commit run --all-files` clean (alejandra, statix, deadnix, markdownlint)
+- [ ] This is a framework improvement, not a personal preference (see [CONTRIBUTING.md](CONTRIBUTING.md))
+- [ ] Docs updated if the change affects bootstrap, profile selection, or module composition
+
+## Related issues
+
+<!-- Closes #N -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,8 +5,8 @@
 ## Checklist
 
 - [ ] `just check` passes (`nix flake check --impure`)
-- [ ] `pre-commit run --all-files` clean (alejandra, statix, deadnix, markdownlint)
-- [ ] This is a framework improvement, not a personal preference (see [CONTRIBUTING.md](CONTRIBUTING.md))
+- [ ] `pre-commit run --all-files` clean (alejandra, markdownlint, secrets scan)
+- [ ] This is a framework improvement, not a personal preference (see [CONTRIBUTING.md](../CONTRIBUTING.md))
 - [ ] Docs updated if the change affects bootstrap, profile selection, or module composition
 
 ## Related issues

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,3 @@
+# Code of Conduct
+
+This project follows the [Contributor Covenant v2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,10 +39,10 @@ Before opening a PR, run:
 
 ```sh
 just check                    # nix flake check --impure
-pre-commit run --all-files    # alejandra, statix, deadnix, markdownlint
+pre-commit run --all-files    # alejandra, markdownlint, trailing whitespace, secrets scan
 ```
 
-Both must pass. CI runs the same checks plus full profile builds for all 16 Linux profiles and all Darwin profiles.
+Both must pass. CI additionally runs `statix` and `deadnix` (Nix linters not in pre-commit) and builds all 16 Linux profiles and all Darwin profiles — so a green pre-commit run does not guarantee a green CI run.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,60 @@
+# Contributing
+
+## This repo is a personal config — and a reusable framework
+
+Two kinds of contributions make sense here, and it helps to know the difference before opening a PR.
+
+### Fork for personal preferences
+
+Tool choices, dotfile content, prompt theming, personal modules, your own username — these belong in your fork. PRs that change personal preferences (e.g. "use neovim instead of vim", "add my preferred aliases") won't be accepted here, but forks are actively encouraged. See [docs/profiles.md](docs/profiles.md) for how to add your own profiles without touching shared code.
+
+### PRs welcome for framework improvements
+
+Improvements to the *framework itself* benefit every adopter and are welcome:
+
+- Bug fixes in activation scripts, module composition, or CI
+- Improvements to `mkProfile`, `mkHomeConfig`, `mkDarwinConfig` helpers in `flake.nix`
+- New module *patterns* (not personal tool choices)
+- Documentation fixes and additions
+- CI/lint pipeline improvements
+
+If you're unsure whether something is framework or personal preference, open an issue first.
+
+---
+
+## Adapting for your own setup
+
+1. Fork this repo
+2. Copy the identity template: `cp user.nix.example user.nix`
+3. Fill in `user.nix` with your username, name, and email
+4. Apply: `nix run home-manager -- switch --flake ~/.nix-config#personal --impure`
+
+See [docs/bootstrap.md](docs/bootstrap.md) for the full first-time setup checklist and [docs/profiles.md](docs/profiles.md) for how to add or customize profiles.
+
+---
+
+## Local validation
+
+Before opening a PR, run:
+
+```sh
+just check                    # nix flake check --impure
+pre-commit run --all-files    # alejandra, statix, deadnix, markdownlint
+```
+
+Both must pass. CI runs the same checks plus full profile builds for all 16 Linux profiles and all Darwin profiles.
+
+---
+
+## PR standards
+
+- One concern per PR
+- Conventional commit message: `fix:`, `feat:`, `docs:`, `refactor:`, `chore:`
+- All CI checks green before requesting review
+- Update docs if the change affects bootstrap, profile selection, or module composition
+
+---
+
+## Reporting issues
+
+For framework bugs or feature ideas, open an issue using the appropriate template. Personal config questions are better suited for a fork or a Nix community forum like [discourse.nixos.org](https://discourse.nixos.org).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # nix-config
 
+[![CI](https://github.com/cdprice02/nix-config/actions/workflows/check.yml/badge.svg)](https://github.com/cdprice02/nix-config/actions/workflows/check.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+
 Personal Nix config managed with [Home Manager](https://github.com/nix-community/home-manager), [nix-darwin](https://github.com/LnL7/nix-darwin), and [rust-overlay](https://github.com/oxalica/rust-overlay). Supports macOS, NixOS, and any Linux/WSL2.
+
+Structured as a composable framework — fork it, fill in `user.nix`, and get a full dev environment on any machine with one command. See [docs/profiles.md](docs/profiles.md) for the profile system and [CONTRIBUTING.md](CONTRIBUTING.md) for how to adapt it to your own setup.
 
 ## Quick start
 
@@ -18,8 +23,7 @@ mkdir -p ~/.config/nix
 echo "experimental-features = nix-command flakes" >> ~/.config/nix/nix.conf
 
 # 3. Clone and configure identity
-git clone git@github.com:cdprice02/nix-config.git ~/.nix-config
-git -C ~/.nix-config submodule update --init
+git clone --recurse-submodules git@github.com:cdprice02/nix-config.git ~/.nix-config
 cp ~/.nix-config/user.nix.example ~/.nix-config/user.nix
 $EDITOR ~/.nix-config/user.nix  # fill in username, name, email
 
@@ -31,11 +35,16 @@ nix run home-manager -- switch --flake ~/.nix-config#personal --impure  # person
 ### macOS
 
 ```sh
-git clone git@github.com:cdprice02/nix-config.git ~/.nix-config
-git -C ~/.nix-config submodule update --init
+# 1. Install Nix
+sh <(curl -L https://nixos.org/nix/install)
+
+# 2. Clone and configure identity
+git clone --recurse-submodules git@github.com:cdprice02/nix-config.git ~/.nix-config
 cp ~/.nix-config/user.nix.example ~/.nix-config/user.nix
 $EDITOR ~/.nix-config/user.nix
-sudo darwin-rebuild switch --flake ~/.nix-config#personal-darwin
+
+# 3. Apply
+sudo darwin-rebuild switch --flake ~/.nix-config#personal-darwin --impure
 ```
 
 ## Daily commands
@@ -80,11 +89,3 @@ docs/
   tools.md         # Tool reference
 ```
 
-## Separate repos
-
-Claude Code and Copilot configs are not in this repo:
-
-```sh
-git clone git@github.com:cdprice02/claude-config ~/.claude
-git clone git@github.com:cdprice02/copilot-config ~/.copilot
-```

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ sudo darwin-rebuild switch --flake ~/.nix-config#personal-darwin --impure
 | Task | Command |
 |------|---------|
 | Apply config (Linux) | `nix-sw` → `home-manager switch --flake ~/.nix-config#<profile> --impure` |
-| Apply config (Mac) | `nix-rb` → `sudo darwin-rebuild switch --flake ~/.nix-config` |
+| Apply config (Mac) | `nix-rb` → `sudo darwin-rebuild switch --flake ~/.nix-config#<profile> --impure` |
 | Update flake inputs | `nix-up` → `nix flake update --flake ~/.nix-config` |
 
 ## Profiles

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -68,7 +68,7 @@ Darwin always includes GUI (`gui-darwin.nix`). Tier is always `dev`.
 
 Bootstrap:
 ```sh
-sudo darwin-rebuild switch --flake ~/.nix-config#personal-darwin
+sudo darwin-rebuild switch --flake ~/.nix-config#personal-darwin --impure
 ```
 
 ## Adding a new profile

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -8,13 +8,17 @@ Common first-boot failures and how to fix them.
 
 **Symptom:** `nix flake` or `home-manager switch` errors with something like:
 
-```
+```text
 error: … builtins.getEnv "HOME" evaluated to ""
 ```
 
-**Fix:** Every `home-manager switch` and `darwin-rebuild switch` requires `--impure`:
+**Fix:** Every `home-manager switch` and `darwin-rebuild switch` requires `--impure`. At first bootstrap, `home-manager` may not be on PATH yet — use the `nix run` form:
 
 ```sh
+# First bootstrap (home-manager not yet on PATH)
+nix run home-manager -- switch --flake ~/.nix-config#<profile> --impure
+
+# Subsequent applies
 home-manager switch --flake ~/.nix-config#<profile> --impure
 sudo darwin-rebuild switch --flake ~/.nix-config#<profile> --impure
 ```
@@ -47,7 +51,7 @@ git clone --recurse-submodules git@github.com:cdprice02/nix-config.git ~/.nix-co
 
 **Symptom:** During `home-manager switch`, the activation script prints:
 
-```
+```text
 WARNING: submodule claude: fetch from private remote failed.
   Ensure your SSH key is added to GitHub, then rerun: home-manager switch --flake ~/.nix-config --impure
 ```
@@ -87,7 +91,7 @@ If you have config in `~/.claude.bk` you want to keep, merge it into `~/.nix-con
 
 **Symptom:** SSL errors from curl, AWS CLI, Python requests, or npm after applying a `work` profile. The activation script also warns:
 
-```
+```text
 WARNING: ~/.certs/corporate.pem not found — see docs/bootstrap.md
 ```
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,126 @@
+# Troubleshooting
+
+Common first-boot failures and how to fix them.
+
+---
+
+## `--impure` omitted → cryptic eval error
+
+**Symptom:** `nix flake` or `home-manager switch` errors with something like:
+
+```
+error: … builtins.getEnv "HOME" evaluated to ""
+```
+
+**Fix:** Every `home-manager switch` and `darwin-rebuild switch` requires `--impure`:
+
+```sh
+home-manager switch --flake ~/.nix-config#<profile> --impure
+sudo darwin-rebuild switch --flake ~/.nix-config#<profile> --impure
+```
+
+`user.nix` is read from the filesystem via `builtins.getEnv "HOME"`, which is an impure operation. This flag is always needed, not just at bootstrap.
+
+---
+
+## Submodule directories empty after clone
+
+**Symptom:** `~/.nix-config/config/claude/` is empty, or Home Manager errors on the symlink activation step.
+
+**Cause:** The repo was cloned without `--recurse-submodules`.
+
+**Fix:**
+
+```sh
+git -C ~/.nix-config submodule update --init --recursive
+```
+
+Or clone correctly from the start:
+
+```sh
+git clone --recurse-submodules git@github.com:cdprice02/nix-config.git ~/.nix-config
+```
+
+---
+
+## SSH key not added to GitHub → submodule fetch fails
+
+**Symptom:** During `home-manager switch`, the activation script prints:
+
+```
+WARNING: submodule claude: fetch from private remote failed.
+  Ensure your SSH key is added to GitHub, then rerun: home-manager switch --flake ~/.nix-config --impure
+```
+
+**Fix:**
+
+```sh
+# Print your public key
+cat ~/.ssh/<sshKey>.pub
+
+# Paste it at: https://github.com/settings/keys
+# Then re-run:
+home-manager switch --flake ~/.nix-config#<profile> --impure
+```
+
+`<sshKey>` is the prefix of your personal email from `user.nix` (e.g. `you` for `you@example.com`).
+
+---
+
+## Home Manager symlink conflict (`~/.claude` already exists)
+
+**Symptom:** Home Manager warns about a backup file or fails to create `~/.claude`.
+
+**Cause:** `~/.claude` exists as a real directory (e.g. from a previous manual install) rather than a symlink. Home Manager uses `backupFileExtension = "bk"` to handle conflicts, so it will rename the existing path to `~/.claude.bk`.
+
+**Fix:** After the switch, verify the symlink is in place:
+
+```sh
+ls -la ~/.claude   # should point to ~/.nix-config/config/claude
+```
+
+If you have config in `~/.claude.bk` you want to keep, merge it into `~/.nix-config/config/claude` before deleting the backup.
+
+---
+
+## `~/.certs/corporate.pem` missing on work profile
+
+**Symptom:** SSL errors from curl, AWS CLI, Python requests, or npm after applying a `work` profile. The activation script also warns:
+
+```
+WARNING: ~/.certs/corporate.pem not found — see docs/bootstrap.md
+```
+
+**Fix:** Obtain the corporate root CA from your IT team and place it at `~/.certs/corporate.pem`:
+
+```sh
+mkdir -p ~/.certs
+cp /path/to/corporate-root-ca.crt ~/.certs/corporate.pem
+```
+
+Then re-run `home-manager switch` to rebuild the combined bundle. See [bootstrap.md](bootstrap.md) for details.
+
+---
+
+## `just` or `home-manager` not found during bootstrap
+
+**Symptom:** `just: command not found` or `home-manager: command not found` on the first run.
+
+**Cause:** These are installed by Home Manager — they aren't on PATH until after the first successful `switch`.
+
+**Fix:** Use the full bootstrap command for the first apply:
+
+```sh
+# Linux / WSL2
+nix run home-manager -- switch --flake ~/.nix-config#<profile> --impure
+
+# macOS
+sudo darwin-rebuild switch --flake ~/.nix-config#<profile> --impure
+```
+
+After the first apply, `just` and `home-manager` are on PATH and you can use the short forms:
+
+```sh
+just switch PROFILE=<profile>   # Linux
+just rebuild PROFILE=<profile>  # macOS
+```


### PR DESCRIPTION
## Summary

- Fixes functional bugs in the README that break first-time setup
- Adds missing docs (troubleshooting guide, contributor workflow, community files)
- Closes #11, Closes #4, Closes #12

## Changes

### Bug fixes

- **README** — macOS quickstart was missing the Nix install step, `--recurse-submodules`, and `--impure` on `darwin-rebuild`; all three will silently break a fresh setup
- **README** — removed outdated "Separate repos" section (`config/claude` and `config/copilot` are now submodules provisioned automatically by Home Manager)
- **docs/profiles.md** — darwin bootstrap example was missing `--impure`

### New docs

- **README** — CI/license badges, one-line project positioning, link to CONTRIBUTING.md
- **docs/troubleshooting.md** — covers `--impure` omission, empty submodules after clone, SSH key not added, Home Manager symlink conflicts, missing corporate cert, and `just`/`home-manager` not on PATH at bootstrap
- **CONTRIBUTING.md** — two-tier model: fork for personal preferences, PR for framework improvements; local validation steps; PR standards
- **CODE_OF_CONDUCT.md** — Contributor Covenant v2.1 reference

### GitHub repo config

- `.github/ISSUE_TEMPLATE/bug_report.yml` — structured bug report (platform, profile, command, error output)
- `.github/ISSUE_TEMPLATE/feature_request.yml` — feature request with framework-vs-personal-preference gate
- `.github/pull_request_template.md` — PR checklist (`just check`, linters, framework rationale, docs updated)

## Test plan

- [x] `nix flake check --impure` passes
- [x] `pre-commit run --all-files` clean
- [x] CI green on push
- [ ] README renders correctly on GitHub (badges, code blocks, no broken links)
- [ ] Walk through the macOS quickstart cold — all steps should work on a fresh machine

Co-Authored-By: Claude <noreply@anthropic.com>