### PR TITLE
fix: TOML escape alacritty keybindings + claude submodule bump

### DIFF
--- a/modules/gui-darwin.nix
+++ b/modules/gui-darwin.nix
@@ -7,39 +7,38 @@
     obsidian
   ];
 
-  # Raw TOML for Cmd/Option+arrow bindings. The chars values are literal
-  # control-character bytes — Nix heredoc strings do not support \u escapes,
-  # so the bytes are embedded directly. Alacritty reads chars as a raw byte
-  # sequence, not TOML escapes. Byte identities:
-  #   Cmd+Left  → 0x01 (Ctrl-A) = readline beginning-of-line
-  #   Cmd+Right → 0x05 (Ctrl-E) = readline end-of-line
-  #   Cmd+Back  → 0x15 (Ctrl-U) = readline kill-to-beginning-of-line
-  #   Opt+Left/Right → ESC b / ESC f = readline backward/forward-word
+  # Cmd/Option+arrow keybindings using TOML \uXXXX escapes (literal control
+  # bytes are invalid TOML). Identities:
+  #   Cmd+Left  -> \u0001 (Ctrl-A) = readline beginning-of-line
+  #   Cmd+Right -> \u0005 (Ctrl-E) = readline end-of-line
+  #   Cmd+Back  -> \u0015 (Ctrl-U) = readline kill-to-beginning-of-line
+  #   Opt+Left  -> \u001bb (ESC b)  = readline backward-word
+  #   Opt+Right -> \u001bf (ESC f)  = readline forward-word
   home.file.".config/alacritty/keybindings.toml".text = ''
     [[keyboard.bindings]]
     key = "Left"
     mods = "Command"
-    chars = ""
+    chars = "\u0001"
 
     [[keyboard.bindings]]
     key = "Right"
     mods = "Command"
-    chars = ""
+    chars = "\u0005"
 
     [[keyboard.bindings]]
     key = "Back"
     mods = "Command"
-    chars = ""
+    chars = "\u0015"
 
     [[keyboard.bindings]]
     key = "Left"
     mods = "Option"
-    chars = "b"
+    chars = "\u001bb"
 
     [[keyboard.bindings]]
     key = "Right"
     mods = "Option"
-    chars = "f"
+    chars = "\u001bf"
   '';
 
   programs = {


### PR DESCRIPTION
## Summary

- Replace literal control character bytes in `keybindings.toml` (generated by `gui-darwin.nix`) with valid TOML `\uXXXX` escape sequences — the raw bytes caused a TOML parse error on darwin rebuild
- Add `github@claude-plugins-official` to bootstrap script so it installs at user scope on fresh machines
- Bump `config/claude` submodule to pick up bootstrap and settings.json changes

## Test plan

- [x] `just rebuild personal-darwin` completes without TOML parse error
- [x] Alacritty keybindings file contains ``, ``, ``, `b`, `f` (no invisible bytes)
- [x] `claude plugin list` shows commit-commands, github, skill-creator all enabled

Co-Authored-By: Claude <noreply@anthropic.com>